### PR TITLE
feat(ops): add health.sh script for container and API checks

### DIFF
--- a/.claude/HANDOFF.md
+++ b/.claude/HANDOFF.md
@@ -1,38 +1,41 @@
-# Handoff — 2026-04-22
+# Handoff — 2026-04-22 (Issue #2)
 
 ## Goal
 
-Create the foundational `docker-compose.yml` for the archon-setup project (Issue #1).
+Deliver `scripts/health.sh` — the first operational script — that verifies the Archon container is running and the `/api/health` endpoint is responsive. Establishes the pattern for subsequent ops scripts.
 
 ## What Was Done
 
-- Created `docker-compose.yml` — pinned `ghcr.io/coleam00/archon:0.3.6`, host-path volume at `${HOME}/archon-data`, read-write mounts for `.archon/workflows` and `.archon/commands`, read-only config mount, localhost-only port, bridge network, healthcheck, DNS, IPv6 sysctl.
-- Created `.env.example` with `CLAUDE_CODE_OAUTH_TOKEN`, `PORT`, `RCLONE_REMOTE` documented.
-- Created `.archon/` skeleton — `workflows/.gitkeep`, `commands/.gitkeep`, `config.yaml` (minimal, commented).
-- Updated `.gitignore` — added `backups/` under a project-specific section.
-- Updated `.claude/scripts/validate.sh` — Type Check block now handles missing `.env` on fresh clones by copying `.env.example` temporarily; adds EXIT trap for safe cleanup; renamed var to `temp_env_created`.
-- Updated `.claude/commands/plan-feature.md` — added `git push -u origin` step after branch creation (per feedback memory).
+- Created `scripts/health.sh` (136 lines, executable):
+  - `#!/usr/bin/env bash` + `set -euo pipefail`.
+  - Named constants: `DEFAULT_PORT=3000`, `HEALTH_ENDPOINT=/api/health`, `CONTAINER_NAME=archon-app`.
+  - `check_deps` — requires `docker` and `curl`, prints install hints on miss.
+  - `check_container` — parses `docker compose ps --format json` for State/Health of `archon-app` (health gate).
+  - `check_api` — `curl -sf --max-time 5` against `http://localhost:${PORT:-3000}/api/health` (health gate).
+  - `check_workflows` — informational count via `docker compose exec -T app archon workflow list | wc -l`; never gates health.
+  - Summary line + `--help` / `-h` flag.
+- Validation: `bash -n` OK, `shellcheck` clean, `.claude/scripts/validate.sh --skip-integration` passed (3 passed, 2 skipped gracefully).
 
 ## Key Decisions
 
-- **Read-write mounts** for workflows/commands (not read-only as original Issue #1 AC stated) — per PLANNING.md architecture decision and Issue #15 correction.
-- **Double `.archon` nesting** in container paths (`/.archon/.archon/workflows`) — Archon resolves scan paths relative to its home dir `/.archon`. Verified in upstream `packages/paths/src/archon-paths.ts`. Comment added in compose file.
-- **`${HOME}` not `~`** in host-path volume — `~` does not expand in Docker Compose.
-- **`ARCHON_DOCKER=true`** required — upstream entrypoint uses it to set archon home to `/.archon`.
+- **`curl` as required dep, not `jq`.** Issue AC listed `jq`; the PRP revised this because the health gate uses `curl` and JSON parsing is done with `grep -o` (dependency-free).
+- **Workflow count is informational only.** No REST endpoint for workflows — listing is CLI-only. Never a health gate.
+- **`PORT` honored to match `docker-compose.yml`.** Uses same var + default (`3000`) so the script hits the right port regardless of user override.
+- **Absolute `-f` path to compose file.** Script resolves `PROJECT_DIR` from its own location so it works from any cwd.
 
 ## Current State
 
-Issue #1 committed and PR created. Branch deleted after merge.
+Branch `feat/issue-2-create-health-sh-script` committed, pushed, PR opened. PRP `.claude/prps/2.md` removed in this commit (git history preserves it). No runtime test against a live container — requires the compose stack running and is out of scope.
 
-## Next Steps (priority order)
+## Next Steps
 
-1. **Issue #15** — Close manually; rw volume mount was implemented as part of Issue #1.
-2. **Issue #2** — `health.sh` script (priority:high)
-3. **Issue #3** — `setup-oauth.sh` script (priority:high)
-4. **Issue #5** — `atyeti-pev.yaml` PEV workflow (priority:high)
-5. **Issue #7** — `docs/SETUP.md` first-time guide (priority:high, blocks team onboarding)
-6. **Issue #8** — `sync-up.sh` / `sync-down.sh` (priority:high)
+1. **Issue #15** — close manually (rw mounts already shipped in #1 PR).
+2. **Issue #3** — `setup-oauth.sh` (priority:high).
+3. **Issue #4** — `backup.sh`.
+4. **Issue #5** — `atyeti-pev.yaml` PEV workflow (priority:high).
+5. **Issue #7** — `docs/SETUP.md` (priority:high, blocks team onboarding).
+6. **Issue #8** — `sync-up.sh` / `sync-down.sh` (priority:high).
 
 ## Issue Tracker Status
 
-- Issue #1: closed via PR. Issue #15: still open — close it with a note that rw mounts were implemented in the Issue #1 PR.
+- #2 — pending PR merge (auto-closes via `Closes #2` in PR body).

--- a/scripts/health.sh
+++ b/scripts/health.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
+readonly DEFAULT_PORT=3000
+readonly HEALTH_ENDPOINT="/api/health"
+readonly CONTAINER_NAME="archon-app"
+
+# Global state written by each check function; read by main() for the summary line.
+CONTAINER_STATUS="not running"
+API_STATUS="unreachable"
+WORKFLOW_COUNT="unknown"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--help]
+
+Checks whether the Archon container is running and its API is responding.
+
+Checks performed:
+  1. Container status  — is ${CONTAINER_NAME} running? (health gate)
+  2. API health        — is ${HEALTH_ENDPOINT} responding? (health gate)
+  3. Workflow count    — how many workflows are loaded? (informational only)
+
+Exit codes:
+  0 — container is running AND API is responding
+  1 — container is down or API is unreachable
+
+Environment variables:
+  PORT   Host port Archon is bound to (default: ${DEFAULT_PORT})
+EOF
+}
+
+check_deps() {
+  local missing=0
+  for cmd in docker curl; do
+    if ! command -v "$cmd" &>/dev/null; then
+      echo "✗ Required tool not found: $cmd"
+      case "$cmd" in
+        docker) echo "  Install Docker: https://docs.docker.com/get-docker/" ;;
+        curl)   echo "  Install curl:  brew install curl  (macOS) | apt-get install curl  (Linux)" ;;
+      esac
+      missing=1
+    fi
+  done
+  if [ "$missing" -ne 0 ]; then
+    exit 1
+  fi
+}
+
+check_container() {
+  echo "→ Checking container status (${CONTAINER_NAME})..."
+
+  local ps_output container_line state health
+  ps_output=$(docker compose -f "${PROJECT_DIR}/docker-compose.yml" ps --format json 2>/dev/null) || ps_output=""
+  container_line=$(echo "$ps_output" | grep "\"Name\":\"${CONTAINER_NAME}\"" 2>/dev/null) || container_line=""
+
+  if [ -z "$container_line" ]; then
+    CONTAINER_STATUS="not running"
+    echo "✗ ${CONTAINER_NAME}: not running (container not found)"
+    return 1
+  fi
+
+  state=$(echo "$container_line" | grep -o '"State":"[^"]*"' | cut -d'"' -f4) || state=""
+  health=$(echo "$container_line" | grep -o '"Health":"[^"]*"' | cut -d'"' -f4) || health=""
+
+  if [ "${state}" != "running" ]; then
+    CONTAINER_STATUS="not running"
+    echo "✗ ${CONTAINER_NAME}: not running (state: ${state:-unknown})"
+    return 1
+  fi
+
+  if [ -n "$health" ]; then
+    CONTAINER_STATUS="running (${health})"
+    echo "✓ ${CONTAINER_NAME}: running (${health})"
+  else
+    CONTAINER_STATUS="running"
+    echo "✓ ${CONTAINER_NAME}: running"
+  fi
+}
+
+check_api() {
+  local port="${PORT:-${DEFAULT_PORT}}"
+  local url="http://localhost:${port}${HEALTH_ENDPOINT}"
+  echo "→ Checking API health (${url})..."
+
+  if curl -sf --max-time 5 "$url" &>/dev/null; then
+    API_STATUS="OK"
+    echo "✓ Archon API: OK"
+  else
+    API_STATUS="unreachable"
+    echo "✗ Archon API: unreachable (${url})"
+    return 1
+  fi
+}
+
+# Informational only — workflow count is never a health gate.
+check_workflows() {
+  echo "→ Checking loaded workflows..."
+
+  local raw_count
+  if raw_count=$(docker compose -f "${PROJECT_DIR}/docker-compose.yml" exec -T app archon workflow list 2>/dev/null | wc -l | tr -d ' '); then
+    WORKFLOW_COUNT="${raw_count}"
+    echo "  Workflows loaded: ${WORKFLOW_COUNT}"
+  else
+    WORKFLOW_COUNT="unknown"
+    echo "  Workflows loaded: unknown"
+  fi
+}
+
+main() {
+  if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    usage
+    exit 0
+  fi
+
+  check_deps
+
+  local overall_ok=0
+  check_container || overall_ok=1
+  check_api || overall_ok=1
+  check_workflows
+
+  echo ""
+  echo "${CONTAINER_NAME}: ${CONTAINER_STATUS} | Archon API: ${API_STATUS} | Workflows loaded: ${WORKFLOW_COUNT}"
+
+  if [ "$overall_ok" -eq 0 ]; then
+    exit 0
+  else
+    exit 1
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Add `scripts/health.sh` — first operational script, establishes the strict-mode + narration + named-constants pattern for all subsequent ops scripts.
- Two health gates: `archon-app` container state via `docker compose ps --format json`, and `/api/health` via `curl -sf --max-time 5`.
- Informational (non-gating) workflow count via `docker compose exec -T app archon workflow list`.
- Honors `PORT` env var (default `3000`) to match `docker-compose.yml`.
- `--help` / `-h` usage flag; exits non-zero if either health gate fails.

## Validation

- `bash -n scripts/health.sh` — OK
- `shellcheck scripts/health.sh` — clean
- `.claude/scripts/validate.sh --skip-integration` — 3 passed, 2 skipped gracefully

Closes #2