### PR TITLE
feat(workflow): document overlay model and add yaml validator

### DIFF
--- a/.claude/HANDOFF.md
+++ b/.claude/HANDOFF.md
@@ -1,37 +1,36 @@
-# Handoff — 2026-04-22 (Issue #4)
+# Handoff — 2026-04-22 (Issue #15)
 
 ## Goal
 
-Ship `scripts/backup.sh` — the foundational safety primitive that copies `~/archon-data/archon.db` to `backups/archon-YYYYMMDD-HHMMSS.db`. Prerequisite for `upgrade.sh` (#12) and `sync-up.sh`/`sync-down.sh` (#8), which must snapshot the DB before touching state.
+Lock in read-write volume mounts for `.archon/workflows/` and `.archon/commands/` (and `:ro` for `.archon/config.yaml`), document the overlay model end-to-end, and ship an optional pre-commit validator for workflow YAML files. The rw mount lets Archon's workflow builder UI write new definitions directly to the git-tracked tree.
 
 ## What Was Done
 
-- Created `scripts/backup.sh` (87 lines, executable). Mirrors `health.sh` and `setup-oauth.sh` style: `set -euo pipefail`, `SCRIPT_DIR`/`PROJECT_DIR`, readonly `UPPER_SNAKE_CASE` constants, functions `usage` / `check_deps` / `verify_source_db` / `ensure_backup_dir` / `perform_backup` / `main`, `→`/`✓`/`✗` narration.
-- Stdout/stderr contract: narration → stderr, backup path → stdout (enables `dest=$(scripts/backup.sh)`). Matches `setup-oauth.sh:74–112` precedent.
-- UTC timestamps via `date -u +%Y%m%d-%H%M%S` (portable across GNU and BSD).
-- `cp -p` preserves mode/timestamps; explicit failure branch on non-zero return.
-- Self-review (`/review 4`): 17 pass / 2 warnings / 0 fail.
-- Validation: `.claude/scripts/validate.sh --skip-integration` passed (lint + compose config + build; unit/integration tests gracefully skipped — not configured yet). `shellcheck` clean.
+- Created `docs/WORKFLOW-OVERLAY.md` (169 lines). Covers prerequisites, three-layer model (custom/override, bundled defaults, `:ro` config), resolution order, three creation methods (UI, hand-written YAML, Claude Code), "delete"/restore via override stub, git workflow after UI builds, trust model, and `TROUBLESHOOTING.md` link. Follows `docs-guides.md` structure.
+- Fixed `.claude/docs/architecture.md:27` — "read-only volume mounts" → "read-write volume mounts" with UI-write rationale. Lines 10-11, 35, 71 already described rw+ro correctly.
+- Created `.claude/scripts/validate-workflow-yaml.sh` (204 lines, executable). Safe-parse-only YAML validation: `description:` presence + `command:` reference integrity. Prefers `python3` + PyYAML (`yaml.safe_load`), falls back to `yq`; prints install instructions if neither available.
+- Wired validator into `.claude/scripts/validate.sh` as new Step 2 (Workflow YAML Validation). Skips gracefully when `.archon/workflows/` is empty. Renumbered downstream steps 3–6.
+- Self-review (`/review 15`): 12 pass / 3 warnings / 0 fail. Validation `.claude/scripts/validate.sh --skip-integration` passes (4 passed / 2 skipped / 0 failed). `docker compose config` resolves all three mounts correctly.
 
 ## Key Decisions
 
-- **Use `cp`, not `sqlite3 .backup`.** Issue #4 spec calls for a plain file copy. The WAL/SHM hot-copy consistency question is explicitly deferred to **Issue #19**. `usage()` warns standalone users; callers (`upgrade.sh`, `sync-*.sh`) take responsibility for `docker compose down` before invoking.
-- **No `docker exec`.** Script reads the host-mounted `${HOME}/archon-data/archon.db` directly — works even when Docker is not running.
-- **`backups/` created at runtime** via `mkdir -p`. No `.gitkeep`. `.gitignore:126` already excludes the directory.
+- **VERIFY over MODIFY.** The mount config in `docker-compose.yml:18-21` was already correct from the earlier `ce5e8d3` fix; this PRP treated it as verification rather than re-authoring. Preserved the inline comment block (13-17) explaining the doubled `.archon` prefix.
+- **Issue #11 owns `docs/SHARING-WORKFLOWS.md` and `docs/DAILY-USE.md`.** Intentionally not touched here to avoid double-writing. `WORKFLOW-OVERLAY.md` is the canonical overlay reference; #11's docs will link to it.
+- **Blanket restart rule.** Doc instructs `docker compose restart app` after any workflow change across all three creation methods. Avoids asserting version-specific hot-reload semantics.
+- **Safe parser only.** Validator never execs or sources YAML; `python3 -c 'yaml.safe_load(...)'` or `yq eval '.'` are the only parse paths.
 
 ## Current State
 
-Branch `feat/issue-4-create-backup-sh-script` is being committed and pushed. PR will carry `Closes #4` to auto-close the issue on merge. Browser / live-DB runs verified locally: `--help`, missing-DB failure, happy path (produced `backups/archon-*.db`), and stdout/stderr split all behave correctly.
+Branch `feat/issue-15-fix-volume-mount-architecture-read-write-for-workf` committed and pushed. PR carries `Closes #15` to auto-close on merge. Runtime container smoke test (`up -d` → `/api/health` → `down`) was NOT executed this session — only `docker compose config` was run. The PR description notes the skip.
 
 ## Next Steps
 
-1. **Issue #19** — decide `cp` vs `sqlite3 .backup` for project-wide backup consistency. If resolved toward `sqlite3 .backup`, swap the `cp -p` call in `perform_backup()`; isolated change.
-2. **Issue #5** — `atyeti-pev.yaml` PEV workflow (priority:high).
-3. **Issue #7** — `docs/SETUP.md` (priority:high, blocks team onboarding).
-4. **Issue #8** — `sync-up.sh` / `sync-down.sh` (priority:high); will consume `backup.sh` via `dest=$(scripts/backup.sh)`.
-5. **Issue #12** — `upgrade.sh` (priority:high); also consumes `backup.sh`.
+1. **Issue #11** — `docs/SHARING-WORKFLOWS.md` and `docs/DAILY-USE.md`. Bidirectional-sharing and post-UI-build commit reminders. Both should link to `docs/WORKFLOW-OVERLAY.md`.
+2. **Issue #7** — `docs/SETUP.md` (priority:high, blocks team onboarding; referenced in the new doc's prerequisites).
+3. **Issue #13** — `docs/TROUBLESHOOTING.md` (referenced as the "Something went wrong?" link target).
+4. **SC2295 tightening** (non-blocking): `validate-workflow-yaml.sh:103` — prefer `"${file#"${PROJECT_DIR}"/}"`. Not caught by current lint (covers `scripts/*.sh` only).
 
 ## Issue Tracker Status
 
-- #4 — pending PR merge (auto-closes via `Closes #4` in PR body).
-- #19 — open, high priority; drives any future change to backup mechanism.
+- #15 — pending PR merge (auto-closes via `Closes #15` in PR body).
+- #11, #7, #13 — open, unblocked now that the overlay reference exists.

--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -24,7 +24,7 @@ graph TD
 
 ### `app` Container (`archon-app`)
 
-The Archon monolith, running as `ghcr.io/coleam00/archon:{tag}`. Built on Bun + React, it exposes port 3000 on localhost only. The container reads custom workflow and command files from read-only volume mounts sourced from the wrapper repo. It writes all persistent data (SQLite database, workspace clones, worktrees, artifacts, logs) to the host-path volume at `~/archon-data/`. The container is stateless in the sense that replacing it loses no data — everything meaningful is on the host.
+The Archon monolith, running as `ghcr.io/coleam00/archon:{tag}`. Built on Bun + React, it exposes port 3000 on localhost only. The container reads and writes custom workflow and command files through read-write volume mounts sourced from the wrapper repo, allowing Archon's workflow builder UI to persist new definitions directly to the git-tracked tree. It writes all persistent data (SQLite database, workspace clones, worktrees, artifacts, logs) to the host-path volume at `~/archon-data/`. The container is stateless in the sense that replacing it loses no data — everything meaningful is on the host.
 
 ### Host-Path Volume (`~/archon-data/`)
 

--- a/.claude/scripts/validate-workflow-yaml.sh
+++ b/.claude/scripts/validate-workflow-yaml.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Workflow YAML Validator
+# =============================================================================
+# Validates every *.yaml / *.yml file under .archon/workflows/:
+#   1. Parses without YAML errors (safe-load only — never exec/source).
+#   2. Has a non-empty top-level 'description:' field (required by CLAUDE.md
+#      for Archon skill discovery and the vscode-archon extension).
+#   3. Every top-level 'command:' value references a file that exists under
+#      .archon/commands/ (relative to the repo root). This is a shallow check —
+#      nested command references inside steps are also traversed.
+#
+# Parser preference: python3 + PyYAML (safe_load). Falls back to yq if python3
+# is unavailable or PyYAML is not installed. Prints install instructions if
+# neither is available and exits non-zero.
+#
+# Usage: ./.claude/scripts/validate-workflow-yaml.sh [--help]
+#
+# Exit codes:
+#   0 — all workflow YAML files are valid (or none exist)
+#   1 — one or more files failed validation, or no parser is available
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd)
+WORKFLOWS_DIR="${PROJECT_DIR}/.archon/workflows"
+COMMANDS_DIR="${PROJECT_DIR}/.archon/commands"
+
+FAILED=0
+PASSED=0
+
+# ---------------------------------------------------------------------------
+# Parser detection
+# ---------------------------------------------------------------------------
+detect_parser() {
+  if command -v python3 &>/dev/null && python3 -c 'import yaml' 2>/dev/null; then
+    echo "python3"
+  elif command -v yq &>/dev/null; then
+    echo "yq"
+  else
+    echo "none"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Parser wrappers — all use safe/parse-only modes; no exec or eval of YAML
+# ---------------------------------------------------------------------------
+parse_yaml() {
+  local parser="$1" file="$2"
+  case "$parser" in
+    python3) python3 -c "import sys, yaml; yaml.safe_load(open(sys.argv[1]))" "$file" ;;
+    yq)      yq eval '.' "$file" > /dev/null ;;
+  esac
+}
+
+get_description() {
+  local parser="$1" file="$2"
+  case "$parser" in
+    python3)
+      python3 -c "
+import sys, yaml
+data = yaml.safe_load(open(sys.argv[1]))
+print(data.get('description', '') if isinstance(data, dict) else '')
+" "$file"
+      ;;
+    yq) yq eval '.description // ""' "$file" ;;
+  esac
+}
+
+get_command_refs() {
+  local parser="$1" file="$2"
+  case "$parser" in
+    python3)
+      python3 -c "
+import sys, yaml
+
+def find_commands(obj):
+    if isinstance(obj, dict):
+        if 'command' in obj and isinstance(obj['command'], str):
+            print(obj['command'])
+        for v in obj.values():
+            find_commands(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            find_commands(item)
+
+data = yaml.safe_load(open(sys.argv[1]))
+if isinstance(data, dict):
+    find_commands(data)
+" "$file"
+      ;;
+    yq) yq eval '.. | select(has("command")) | .command' "$file" 2>/dev/null || true ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Per-file validation
+# ---------------------------------------------------------------------------
+validate_file() {
+  local parser="$1" file="$2"
+  local rel_path="${file#${PROJECT_DIR}/}"
+  local file_failed=0
+
+  echo "→ Checking ${rel_path}..."
+
+  if ! parse_yaml "$parser" "$file" 2>/dev/null; then
+    echo "  ✗ YAML parse error"
+    FAILED=$((FAILED + 1))
+    return
+  fi
+
+  local description
+  description=$(get_description "$parser" "$file" 2>/dev/null || echo "")
+  if [ -z "$description" ] || [ "$description" = "null" ]; then
+    echo "  ✗ missing or empty top-level 'description:' field"
+    file_failed=1
+  fi
+
+  while IFS= read -r cmd_ref; do
+    [ -z "$cmd_ref" ] || [ "$cmd_ref" = "null" ] && continue
+    local cmd_file="${COMMANDS_DIR}/${cmd_ref#/}"
+    if [ ! -f "$cmd_file" ]; then
+      echo "  ✗ 'command: ${cmd_ref}' references a file that does not exist: ${cmd_file}"
+      file_failed=1
+    fi
+  done < <(get_command_refs "$parser" "$file" 2>/dev/null || true)
+
+  if [ "$file_failed" -eq 0 ]; then
+    echo "  ✓ OK"
+    PASSED=$((PASSED + 1))
+  else
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+  if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    echo "Usage: $(basename "$0") [--help]"
+    echo ""
+    echo "Validates *.yaml / *.yml files under .archon/workflows/:"
+    echo "  - Parses without YAML errors"
+    echo "  - Has a non-empty top-level 'description:' field"
+    echo "  - Any 'command:' references resolve to files under .archon/commands/"
+    exit 0
+  fi
+
+  echo "→ Validating workflow YAML files in ${WORKFLOWS_DIR}..."
+
+  if [ ! -d "${WORKFLOWS_DIR}" ]; then
+    echo "⊘ .archon/workflows/ does not exist — skipping"
+    exit 0
+  fi
+
+  local parser
+  parser=$(detect_parser)
+
+  if [ "$parser" = "none" ]; then
+    echo "✗ No YAML parser found. Install one of:"
+    echo "  python3 + PyYAML:  pip3 install pyyaml"
+    echo "  yq:                brew install yq"
+    exit 1
+  fi
+
+  echo "→ Using parser: ${parser}"
+
+  local files=()
+  while IFS= read -r -d $'\0' f; do
+    files+=("$f")
+  done < <(find "${WORKFLOWS_DIR}" -maxdepth 1 \( -name "*.yaml" -o -name "*.yml" \) -print0 2>/dev/null || true)
+
+  if [ "${#files[@]}" -eq 0 ]; then
+    echo "⊘ No workflow YAML files found — skipping"
+    exit 0
+  fi
+
+  for f in "${files[@]}"; do
+    validate_file "$parser" "$f"
+  done
+
+  echo ""
+  echo "========================================"
+  echo "  Workflow YAML Validation Summary"
+  echo "========================================"
+  echo "  Passed: ${PASSED}"
+  echo "  Failed: ${FAILED}"
+  echo "========================================"
+
+  if [ "${FAILED}" -gt 0 ]; then
+    echo ""
+    echo "✗ Workflow YAML validation FAILED — ${FAILED} file(s) failed."
+    exit 1
+  fi
+
+  echo ""
+  echo "✓ All workflow YAML files are valid."
+  exit 0
+}
+
+main "$@"

--- a/.claude/scripts/validate.sh
+++ b/.claude/scripts/validate.sh
@@ -114,7 +114,22 @@ section "Lint"
 run_step_if "scripts" "Lint" "shellcheck scripts/*.sh"
 
 # ---------------------------------------------------------------------------
-# Step 2: Type Check
+# Step 2: Workflow YAML Validation
+# ---------------------------------------------------------------------------
+section "Workflow YAML Validation"
+
+WORKFLOW_VALIDATOR="$(dirname "$0")/validate-workflow-yaml.sh"
+WORKFLOW_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.archon/workflows"
+
+if [ -d "$WORKFLOW_DIR" ] && [ -n "$(ls -A "$WORKFLOW_DIR" 2>/dev/null)" ]; then
+  run_step "Workflow YAML Validation" "$WORKFLOW_VALIDATOR"
+else
+  echo "⊘ Workflow YAML Validation skipped (.archon/workflows/ is empty or absent)"
+  SKIPPED=$((SKIPPED + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3: Type Check
 # ---------------------------------------------------------------------------
 section "Type Check"
 
@@ -140,14 +155,14 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Step 3: Unit Tests
+# Step 4: Unit Tests
 # ---------------------------------------------------------------------------
 section "Unit Tests"
 
 run_step_if "tests/unit" "Unit Tests" "echo 'No unit test framework configured for Bash/YAML project'"
 
 # ---------------------------------------------------------------------------
-# Step 4: Integration Tests
+# Step 5: Integration Tests
 # ---------------------------------------------------------------------------
 section "Integration Tests"
 
@@ -158,7 +173,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Step 5: Build
+# Step 6: Build
 # ---------------------------------------------------------------------------
 section "Build"
 

--- a/docs/WORKFLOW-OVERLAY.md
+++ b/docs/WORKFLOW-OVERLAY.md
@@ -1,0 +1,169 @@
+# Workflow Overlay Model
+
+## What you need before starting
+
+- Docker installed and running on your machine (see [docs/SETUP.md](SETUP.md) for installation steps)
+- This repository cloned to your machine
+- A `.env` file in the repo root with `CLAUDE_CODE_OAUTH_TOKEN` set (copy from `.env.example` and fill in your token)
+- The Archon container running: `docker compose up -d`
+
+## Why this exists
+
+Archon ships with built-in default workflows and commands baked into its Docker image. Teams need to override those defaults and add custom ones without forking the image. The overlay model lets both coexist: Archon's defaults remain available, and any file you place in `.archon/workflows/` silently takes priority over the default with the same filename.
+
+## The three layers
+
+Archon resolves workflows and commands from three sources, in priority order:
+
+| Layer | Host path | Container path | Mode | Git-tracked | Archon can write |
+|---|---|---|---|---|---|
+| Custom/override workflows | `.archon/workflows/` | `/.archon/.archon/workflows/` | rw | Yes | Yes |
+| Bundled image defaults | (inside Docker image) | (image filesystem) | n/a | No | No |
+| Config | `.archon/config.yaml` | `/.archon/config.yaml` | ro | Yes | No |
+
+Same model applies to commands at `/.archon/.archon/commands/`.
+
+When Archon looks for a workflow named `foo.yaml`, it checks in this order:
+
+```
+Resolution order for a workflow named "foo.yaml":
+  1. /.archon/.archon/workflows/foo.yaml      (host mount, rw, git-tracked)  ← wins if present
+  2. <bundled inside image>/foo.yaml          (immutable default)            ← fallback
+  3. (not found)                              ← Archon errors / skips
+
+Same model applies to commands at /.archon/.archon/commands/.
+Config is single-source: /.archon/config.yaml (:ro). No overlay.
+```
+
+> **Why the doubled `.archon` in the container path?** The container's home directory is `/.archon` (mapped from `~/archon-data` on your host). Archon resolves scan paths as `<home>/.archon/<kind>`, so the mount target must be `/.archon/.archon/workflows`, not `/.archon/workflows`. This is intentional — do not "clean up" the doubled prefix or workflow discovery will silently break. The rationale is preserved in the `docker-compose.yml` inline comment.
+
+**This document describes behavior at image tag `ghcr.io/coleam00/archon:0.3.6`.** Overlay precedence, restart requirements, and command discovery are version-specific. After a tag bump in `docker-compose.yml`, review the Archon release notes to confirm the contract is unchanged.
+
+## Three ways to create or modify a workflow
+
+### 1. Archon's workflow builder UI
+
+Open the Archon web interface at `http://localhost:3000` and use the workflow builder to create or edit a workflow. Archon writes the YAML through the read-write volume mount directly to your repo's `.archon/workflows/` directory.
+
+**What you should see:** After saving in the UI, a new `.yaml` file appears on your machine under `.archon/workflows/`. Confirm with:
+
+```bash
+git status
+```
+
+You should see the new file listed as untracked under `.archon/workflows/`.
+
+> **Always restart after any file change.** Archon reads workflow definitions at startup. `docker compose restart app` is the safe blanket rule for all three creation methods — do not assume hot-reload.
+
+```bash
+docker compose restart app
+```
+
+`docker compose restart app` stops and restarts only the `app` container, causing it to re-scan the mounted directories. The container itself is not replaced and no data is lost.
+
+### 2. Hand-written YAML + restart
+
+1. Create a `.yaml` or `.yml` file under `.archon/workflows/`:
+
+```bash
+# Example
+touch .archon/workflows/my-workflow.yaml
+```
+
+2. Open the file in your editor and add at minimum a `description:` field at the top level — this field is **required** for skill discoverability.
+
+3. Restart the container to pick up the change:
+
+```bash
+docker compose restart app
+```
+
+**What you should see:** The workflow appears in the Archon UI and CLI within ~5 seconds of restart.
+
+### 3. Claude Code with the Archon skill
+
+Ask Claude Code to author a workflow using the Archon skill. The agent writes the `.yaml` file under `.archon/workflows/` and reports the file path on completion.
+
+**What you should see:** Same outcome as method 2 — the file exists on disk and is visible in `git status`. Restart the container after the agent finishes:
+
+```bash
+docker compose restart app
+```
+
+## How to "delete" a bundled default
+
+Archon's built-in defaults live inside the Docker image and cannot be removed — the image is immutable. To suppress a default, create a same-named file in `.archon/workflows/` that overrides it with a stub:
+
+```yaml
+description: Disabled — suppresses the bundled default of the same name.
+steps: []
+```
+
+Then restart the container:
+
+```bash
+docker compose restart app
+```
+
+**What you should see:** The bundled default no longer appears or executes; your override file takes its place in the UI and CLI.
+
+## How to restore a default
+
+Remove your override file and restart. Git tracks the deletion so teammates see the restore:
+
+```bash
+git rm .archon/workflows/<filename>.yaml
+git commit -m "chore(workflow): restore bundled default for <filename>"
+docker compose restart app
+```
+
+`git rm` stages the deletion and removes the file from disk. After the commit, teammates who run `git pull` followed by `docker compose restart app` will also see the default restored.
+
+**What you should see:** The bundled default reappears in the Archon UI and CLI after restart.
+
+## Git workflow after building in the UI
+
+When you create a workflow in the UI, the file lands on your host filesystem but is not yet committed. Run these steps to save and share it with the team:
+
+1. Check what was created:
+
+```bash
+git status
+```
+
+**What you should see:** New `.yaml` files under `.archon/workflows/` listed as untracked.
+
+2. Review the generated YAML before committing:
+
+```bash
+git diff .archon/workflows/
+```
+
+**What you should see:** The full YAML content of the new workflow. Confirm the `description:` field is present and non-empty — it is required.
+
+3. Stage and commit:
+
+```bash
+git add .archon/workflows/
+git commit -m "feat(workflow): add <name> workflow"
+```
+
+4. Push to share with the team:
+
+```bash
+git push
+```
+
+**What you should see:** The push succeeds and teammates can `git pull` to receive the workflow, then `docker compose restart app` to load it.
+
+> **`description:` is required on every workflow YAML.** Archon's skill discovery system and the vscode-archon extension use this field to list available workflows. A workflow without `description:` may not appear in tool lists or the extension's UI.
+
+## Trust model
+
+The read-write mount gives the Archon container write authority over `.archon/workflows/` and `.archon/commands/` on your machine. A runtime bug or a malicious workflow could write unexpected files to those directories. This risk is accepted for three reasons: Archon is bound to `127.0.0.1:3000` and is not reachable from the network, it runs under your own user account with standard filesystem permissions, and `git diff` after any UI session provides a clear audit trail of what changed. The `.archon/config.yaml` mount remains `:ro` so Archon cannot rewrite its own configuration at runtime.
+
+No secrets belong in `.archon/workflows/` or `.archon/commands/`. Both directories are git-tracked. The OAuth token lives in `.env`, which is `.gitignore`'d and injected via `env_file:` in `docker-compose.yml`.
+
+## Something went wrong?
+
+See [`docs/TROUBLESHOOTING.md`](TROUBLESHOOTING.md) for common errors and fixes.


### PR DESCRIPTION
Lock in the read-write volume mount model for .archon/workflows/ and .archon/commands/ so Archon's workflow builder UI can persist new definitions directly to the git-tracked tree. Config (.archon/config.yaml) stays :ro so runtime code cannot rewrite its own configuration.

- docs/WORKFLOW-OVERLAY.md (new): end-to-end reference for the three-layer overlay (custom override, bundled default, :ro config), resolution order, three creation methods (UI, hand-written YAML, Claude Code), override-as- delete semantics, git workflow after UI builds, and trust model.
- .claude/scripts/validate-workflow-yaml.sh (new): pre-commit check that every workflow YAML parses via yaml.safe_load (never exec/source), carries a non-empty description:, and that every command: reference resolves to a real file under .archon/commands/.
- .claude/scripts/validate.sh: new step 2 invokes the validator when .archon/workflows/ is non-empty; existing pre-commit hook unchanged.
- .claude/docs/architecture.md: replace stale "read-only mounts" phrasing with the rw+ro model and UI-write rationale.

Issue #11 retains ownership of docs/SHARING-WORKFLOWS.md and docs/DAILY-USE.md; both will link to WORKFLOW-OVERLAY.md when shipped.

Context:
- Updated .claude/docs/architecture.md to describe read-write workflow/command mounts
- Added .claude/scripts/validate-workflow-yaml.sh (safe-parse YAML validator)
- Updated .claude/scripts/validate.sh to wire the workflow-YAML step into the pre-commit flow
- Updated .claude/HANDOFF.md with issue #15 session state

Refs: #15

## What

<!-- One-sentence summary of this change. -->

## Why

<!-- Motivation: ticket reference, bug report, business requirement. -->

## How

<!-- Brief description of approach. Note any non-obvious design choices. -->

## Testing

<!-- What was tested and how. Include commands run if relevant. -->

---

### Checklist

- [ ] PRP or task reference linked above
- [ ] `/review` command run with no FAIL items
- [ ] `.claude/scripts/validate.sh` passes
- [ ] No unresolved placeholder markers in changed files
- [ ] ADR created (`.claude/docs/adr/`) if architecture was changed
