### PR TITLE
feat(ops): add sync-up.sh and sync-down.sh for cross-machine data sync

### DIFF
--- a/.claude/HANDOFF.md
+++ b/.claude/HANDOFF.md
@@ -1,34 +1,30 @@
-# Handoff — Issue #24 complete (PARTIAL)
+# Handoff — Issue #8: sync-up.sh and sync-down.sh
 
 ## Goal
-Verify that workflows authored in the Archon 0.3.6 browser UI write to the host bind-mount at `.archon/workflows/` and survive `docker compose restart app`.
+Create two host-run Bash scripts for cross-machine data sync via rclone, enabling the laptop-desktop workflow.
 
 ## What Was Done
-- Ran live smoke test: UI workflow builder found at `Workflows → + New Workflow → /workflows/builder`.
-- **Bind-mount write-back: CONFIRMED.** File `smoke-test.yaml` appeared on host within ~5 seconds of clicking Save.
-- **SQLite persistence: UNCONFIRMED.** Save stalled at ~89% — Archon makes an outbound Claude API call during save (model validation/compilation). Call hung, likely expired `CLAUDE_CODE_OAUTH_TOKEN` (see issue #25). SQLite record never written; `/api/workflows` returned `{"workflows":[]}`.
-- **Key structural finding:** Archon's UI Workflows page reads from SQLite, not YAML files on disk. Startup log confirms no scan of `/.archon/.archon/workflows/` at boot — only bundled defaults at `/app/.archon/workflows/defaults/` are loaded.
-- Filed **issue #30**: verify whether a hand-placed YAML in `.archon/workflows/` appears in Archon's UI after restart (the unverified git-sharing model). Depends on #25 being resolved first.
-- Commented on **issue #25** with Test 24 as supporting evidence for Outcome C (expired token).
-- Filled Test 24 slot in `.claude/docs/smoke-tests.md`: pending → PARTIAL with full verbatim evidence.
-- Updated `docs/WORKFLOW-OVERLAY.md` §1: added two caveats (API call gates save; SQLite is UI source of truth, not YAML files).
+- Created `scripts/sync-up.sh` (181 lines) — stops Archon, backs up DB, syncs `~/archon-data/` to rclone remote. Defaults to NOT restarting (operator is leaving this machine).
+- Created `scripts/sync-down.sh` (223 lines) — stops Archon, pulls rclone remote to `~/archon-data/`, restarts by default (operator just arrived). Requires `--yes` or interactive `YES` confirmation before overwriting local data.
+- Both scripts: `set -euo pipefail`, dep checks (docker + rclone with install hints), `RCLONE_REMOTE` fallback chain (shell env, `.env`, `gdrive:archon-data`), remote verification via `rclone listremotes`, `docker compose down` (not stop) before any sync, `--dry-run` passthrough, `--help` self-documentation, narration markers to stderr.
+- All static validation passed: `bash -n`, `shellcheck` (zero warnings), executable bits, `--help` grep checks, missing-tool narration check.
 
 ## Key Decisions
-- PARTIAL (not FAIL): the bind-mount write IS real; the failure was in the API-gated SQLite write blocked by a likely expired token.
-- Removed "always restart" blanket note from §1 — misleading for UI-authored workflows where restart can't recover an incomplete save.
+- Scripts are fully self-contained (no shared lib) — matches project convention where existing scripts share no code.
+- `read_env_key()` uses `grep`+`cut` (not `source .env`) to avoid shell metacharacter issues under `set -u`.
+- rclone flags use array-based approach for shellcheck compliance.
+- sync-up calls `backup.sh` after `docker compose down` (not before) per backup.sh's own usage contract.
 
 ## Current State
-- PR open on `feat/issue-24-...` → auto-closes #24 on merge.
-- Container healthy on port 3000. `archon.db` at `~/archon-data/archon.db`.
+- PR created on `feat/issue-8-...` branch, auto-closes #8 on merge.
+- Live rclone sync tests are operator-only (rclone not installed in agent env). Static validation complete.
 
 ## Next Steps
-1. **Issue #25** — resolve OAuth token lifetime; fix so Archon can complete outbound API calls during workflow save.
-2. **Issue #30** — after #25: hand-place a valid YAML in `.archon/workflows/`, verify it appears in UI after restart. Use bundled schema (`model: sonnet`, block-style `nodes:`).
-3. **Issue #19** — backup consistency model (cp vs sqlite3 .backup).
-4. **Issue #12** — upgrade.sh script.
-5. Remaining docs: #11 (SHARING-WORKFLOWS + DAILY-USE), #9 (SYNC-BETWEEN-MACHINES), #13 (UPGRADING + TROUBLESHOOTING).
+1. **Issue #9** — Write `docs/SYNC-BETWEEN-MACHINES.md` (companion doc for these scripts).
+2. **Issue #12** — Create `upgrade.sh` script with backup safety.
+3. **Issue #19** — Define backup consistency model (cp vs sqlite3 .backup).
+4. Remaining docs: #11 (SHARING-WORKFLOWS + DAILY-USE), #13 (UPGRADING + TROUBLESHOOTING).
 
 ## Issue Tracker
-- #24: closing via this PR
-- #25: open, unblocked — Test 24 evidence added as comment
-- #30: open, blocks on #25
+- #8: closing via this PR
+- #9: open, unblocked — can now reference the delivered scripts

--- a/scripts/sync-down.sh
+++ b/scripts/sync-down.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+readonly DATA_DIR="${HOME}/archon-data"
+readonly COMPOSE_FILE="${PROJECT_DIR}/docker-compose.yml"
+readonly ENV_FILE="${PROJECT_DIR}/.env"
+readonly DEFAULT_REMOTE="gdrive:archon-data"
+readonly CONTAINER_NAME="archon-app"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Syncs \$RCLONE_REMOTE → ~/archon-data. Stops Archon first, restarts after.
+
+WARNING: This will OVERWRITE ${DATA_DIR} with contents of the remote.
+Any local data not yet synced to the remote will be lost.
+
+Stops Archon (docker compose down) → pulls ${DATA_DIR} from the configured
+rclone remote → restarts Archon by default. Use --no-restart to keep it down.
+
+Requires --yes or interactive confirmation to protect against accidental
+data loss. Pass --yes for non-interactive use (scripts, CI-equivalent).
+
+HARD CONSTRAINT: SQLite does not handle concurrent writers. Archon must
+be stopped before sync so the WAL checkpoint completes and the local
+data directory is consistent.
+
+Options:
+  --yes          Skip interactive confirmation (required for non-TTY use)
+  --no-restart   Do not start Archon after sync (default: restart)
+  --restart      Start Archon after sync (default)
+  --dry-run      Pass --dry-run to rclone; does not transfer files
+  -h, --help     Show this help and exit
+
+Environment variables:
+  RCLONE_REMOTE  rclone remote:path source (default: ${DEFAULT_REMOTE})
+                 Read from: shell env → .env → literal default
+
+Exit codes:
+  0  success
+  1  any failure (missing tool, misconfigured remote, user declined, sync failure)
+EOF
+}
+
+check_deps() {
+  local missing=0
+  for cmd in docker rclone; do
+    if ! command -v "${cmd}" &>/dev/null; then
+      echo "✗ Required tool not found: ${cmd}" >&2
+      case "${cmd}" in
+        docker) echo "  Install Docker: https://docs.docker.com/get-docker/" >&2 ;;
+        rclone) echo "  Install rclone: brew install rclone  (macOS)" >&2
+                echo "                  apt-get install rclone  (Linux)" >&2
+                echo "                  https://rclone.org/install/" >&2 ;;
+      esac
+      missing=1
+    fi
+  done
+  if [[ "${missing}" -ne 0 ]]; then
+    exit 1
+  fi
+}
+
+read_env_key() {
+  local key="$1"
+  [[ ! -f "${ENV_FILE}" ]] && return 0
+  local match
+  if match=$(grep "^${key}=" "${ENV_FILE}"); then
+    printf '%s\n' "${match}" | head -n1 | cut -d'=' -f2-
+  fi
+}
+
+resolve_remote() {
+  if [[ -n "${RCLONE_REMOTE:-}" ]]; then
+    printf '%s' "${RCLONE_REMOTE}"
+    return 0
+  fi
+  local env_val
+  env_val=$(read_env_key "RCLONE_REMOTE")
+  if [[ -n "${env_val}" ]]; then
+    printf '%s' "${env_val}"
+    return 0
+  fi
+  printf '%s' "${DEFAULT_REMOTE}"
+}
+
+verify_remote() {
+  local remote="$1"
+  local prefix="${remote%%:*}"
+  echo "→ Verifying rclone remote '${prefix}:' is configured..." >&2
+  if ! rclone listremotes | grep -q "^${prefix}:$"; then
+    echo "✗ rclone remote '${prefix}:' is not configured. Run: rclone config" >&2
+    exit 1
+  fi
+  echo "✓ Remote '${prefix}:' found" >&2
+}
+
+stop_archon() {
+  echo "→ Stopping Archon (${CONTAINER_NAME}) via docker compose down..." >&2
+  local running
+  running=$(docker compose -f "${COMPOSE_FILE}" ps -q 2>/dev/null || true)
+  if [[ -z "${running}" ]]; then
+    echo "✓ Archon already stopped" >&2
+    return 0
+  fi
+  docker compose -f "${COMPOSE_FILE}" down
+  echo "✓ Archon stopped" >&2
+}
+
+ensure_data_dir() {
+  echo "→ Ensuring data directory exists: ${DATA_DIR}" >&2
+  mkdir -p "${DATA_DIR}"
+  echo "✓ Data directory ready" >&2
+}
+
+confirm_destructive() {
+  local remote="$1"
+  local auto_yes="$2"
+
+  if [[ "${auto_yes}" == "true" ]]; then
+    return 0
+  fi
+
+  if [[ ! -t 0 ]]; then
+    echo "✗ stdin is not a terminal. Pass --yes to confirm non-interactively." >&2
+    exit 1
+  fi
+
+  echo "" >&2
+  echo "WARNING: This will OVERWRITE ${DATA_DIR} with contents of ${remote}." >&2
+  if [[ -f "${DATA_DIR}/archon.db" ]]; then
+    local db_size
+    db_size=$(du -h "${DATA_DIR}/archon.db" | cut -f1)
+    echo "  Local DB: ${DATA_DIR}/archon.db (${db_size})" >&2
+  elif [[ -d "${DATA_DIR}" ]]; then
+    echo "  Local: ${DATA_DIR} (no archon.db found)" >&2
+  else
+    echo "  Local: ${DATA_DIR} does not exist yet" >&2
+  fi
+  echo "" >&2
+  printf 'Type YES to proceed: ' >&2
+  local answer
+  if ! read -r answer; then
+    echo "" >&2
+    echo "✗ Aborted (no input)." >&2
+    exit 1
+  fi
+  if [[ "${answer}" != "YES" ]]; then
+    echo "✗ Aborted." >&2
+    exit 1
+  fi
+}
+
+do_sync() {
+  local remote="$1"
+  local dry_run="$2"
+  local start="${SECONDS}"
+  local -a flags=(--stats-one-line --stats=5s)
+  if [[ "${dry_run}" == "true" ]]; then
+    flags+=(--dry-run)
+  fi
+
+  echo "→ Syncing ${remote} → ${DATA_DIR}..." >&2
+  if ! rclone sync "${remote}" "${DATA_DIR}" "${flags[@]}"; then
+    echo "✗ rclone sync failed" >&2
+    exit 1
+  fi
+  local elapsed=$(( SECONDS - start ))
+  echo "✓ Sync complete in ${elapsed}s" >&2
+}
+
+restart_archon() {
+  echo "→ Starting Archon..." >&2
+  docker compose -f "${COMPOSE_FILE}" up -d
+  echo "→ Validating health..." >&2
+  "${PROJECT_DIR}/scripts/health.sh"
+}
+
+main() {
+  local auto_yes=false
+  local restart=true
+  local dry_run=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --yes)        auto_yes=true ;;
+      --restart)    restart=true ;;
+      --no-restart) restart=false ;;
+      --dry-run)    dry_run=true ;;
+      -h|--help)    usage; exit 0 ;;
+      *) echo "✗ Unknown flag: $1" >&2; usage >&2; exit 1 ;;
+    esac
+    shift
+  done
+
+  local script_start="${SECONDS}"
+
+  check_deps
+
+  local remote
+  remote=$(resolve_remote)
+  echo "→ Remote: ${remote}" >&2
+
+  verify_remote "${remote}"
+  confirm_destructive "${remote}" "${auto_yes}"
+  stop_archon
+  ensure_data_dir
+  do_sync "${remote}" "${dry_run}"
+
+  if [[ "${restart}" == "true" ]]; then
+    restart_archon
+  fi
+
+  local elapsed=$(( SECONDS - script_start ))
+  echo ""
+  echo "✓ sync-down complete in ${elapsed}s ← ${remote}"
+}
+
+main "$@"

--- a/scripts/sync-up.sh
+++ b/scripts/sync-up.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+readonly DATA_DIR="${HOME}/archon-data"
+readonly COMPOSE_FILE="${PROJECT_DIR}/docker-compose.yml"
+readonly ENV_FILE="${PROJECT_DIR}/.env"
+readonly DEFAULT_REMOTE="gdrive:archon-data"
+readonly CONTAINER_NAME="archon-app"
+readonly BACKUP_SCRIPT="${PROJECT_DIR}/scripts/backup.sh"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Syncs ~/archon-data → \$RCLONE_REMOTE. Stops Archon first.
+
+Stops Archon (docker compose down) → creates a timestamped backup of
+archon.db → syncs ${DATA_DIR} to the configured rclone remote.
+Archon stays down after sync by default (--restart to bring it back up).
+
+HARD CONSTRAINT: SQLite does not handle concurrent writers. Archon must
+be stopped before sync so the WAL checkpoint completes and the replica
+on the remote is consistent.
+
+Options:
+  --restart      Bring Archon back up after sync (default: off)
+  --no-restart   Do not restart after sync (default)
+  --dry-run      Pass --dry-run to rclone; does not transfer files
+  -h, --help     Show this help and exit
+
+Environment variables:
+  RCLONE_REMOTE  rclone remote:path target (default: ${DEFAULT_REMOTE})
+                 Read from: shell env → .env → literal default
+
+Exit codes:
+  0  success
+  1  any failure (missing tool, misconfigured remote, sync failure)
+EOF
+}
+
+check_deps() {
+  local missing=0
+  for cmd in docker rclone; do
+    if ! command -v "${cmd}" &>/dev/null; then
+      echo "✗ Required tool not found: ${cmd}" >&2
+      case "${cmd}" in
+        docker) echo "  Install Docker: https://docs.docker.com/get-docker/" >&2 ;;
+        rclone) echo "  Install rclone: brew install rclone  (macOS)" >&2
+                echo "                  apt-get install rclone  (Linux)" >&2
+                echo "                  https://rclone.org/install/" >&2 ;;
+      esac
+      missing=1
+    fi
+  done
+  if [[ "${missing}" -ne 0 ]]; then
+    exit 1
+  fi
+}
+
+read_env_key() {
+  local key="$1"
+  [[ ! -f "${ENV_FILE}" ]] && return 0
+  local match
+  if match=$(grep "^${key}=" "${ENV_FILE}"); then
+    printf '%s\n' "${match}" | head -n1 | cut -d'=' -f2-
+  fi
+}
+
+resolve_remote() {
+  if [[ -n "${RCLONE_REMOTE:-}" ]]; then
+    printf '%s' "${RCLONE_REMOTE}"
+    return 0
+  fi
+  local env_val
+  env_val=$(read_env_key "RCLONE_REMOTE")
+  if [[ -n "${env_val}" ]]; then
+    printf '%s' "${env_val}"
+    return 0
+  fi
+  printf '%s' "${DEFAULT_REMOTE}"
+}
+
+verify_remote() {
+  local remote="$1"
+  local prefix="${remote%%:*}"
+  echo "→ Verifying rclone remote '${prefix}:' is configured..." >&2
+  if ! rclone listremotes | grep -q "^${prefix}:$"; then
+    echo "✗ rclone remote '${prefix}:' is not configured. Run: rclone config" >&2
+    exit 1
+  fi
+  echo "✓ Remote '${prefix}:' found" >&2
+}
+
+stop_archon() {
+  echo "→ Stopping Archon (${CONTAINER_NAME}) via docker compose down..." >&2
+  local running
+  running=$(docker compose -f "${COMPOSE_FILE}" ps -q 2>/dev/null || true)
+  if [[ -z "${running}" ]]; then
+    echo "✓ Archon already stopped" >&2
+    return 0
+  fi
+  docker compose -f "${COMPOSE_FILE}" down
+  echo "✓ Archon stopped" >&2
+}
+
+run_backup() {
+  echo "→ Creating pre-sync backup..." >&2
+  local backup_path
+  if backup_path=$("${BACKUP_SCRIPT}"); then
+    echo "✓ Pre-sync backup complete: ${backup_path}" >&2
+  else
+    echo "! No database to back up yet (first sync?). Continuing." >&2
+  fi
+}
+
+do_sync() {
+  local remote="$1"
+  local dry_run="$2"
+  local start="${SECONDS}"
+  local -a flags=(--stats-one-line --stats=5s)
+  if [[ "${dry_run}" == "true" ]]; then
+    flags+=(--dry-run)
+  fi
+
+  echo "→ Syncing ${DATA_DIR} → ${remote}..." >&2
+  if ! rclone sync "${DATA_DIR}" "${remote}" "${flags[@]}"; then
+    echo "✗ rclone sync failed" >&2
+    exit 1
+  fi
+  local elapsed=$(( SECONDS - start ))
+  echo "✓ Sync complete in ${elapsed}s" >&2
+}
+
+restart_archon() {
+  echo "→ Starting Archon..." >&2
+  docker compose -f "${COMPOSE_FILE}" up -d
+  echo "→ Validating health..." >&2
+  "${PROJECT_DIR}/scripts/health.sh"
+}
+
+main() {
+  local restart=false
+  local dry_run=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --restart)    restart=true ;;
+      --no-restart) restart=false ;;
+      --dry-run)    dry_run=true ;;
+      -h|--help)    usage; exit 0 ;;
+      *) echo "✗ Unknown flag: $1" >&2; usage >&2; exit 1 ;;
+    esac
+    shift
+  done
+
+  local script_start="${SECONDS}"
+
+  check_deps
+
+  local remote
+  remote=$(resolve_remote)
+  echo "→ Remote: ${remote}" >&2
+
+  verify_remote "${remote}"
+  stop_archon
+  run_backup
+  do_sync "${remote}" "${dry_run}"
+
+  if [[ "${restart}" == "true" ]]; then
+    restart_archon
+  fi
+
+  local elapsed=$(( SECONDS - script_start ))
+  echo ""
+  echo "✓ sync-up complete in ${elapsed}s → ${remote}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Add `scripts/sync-up.sh` — stops Archon, backs up DB, syncs `~/archon-data/` → rclone remote (default: no restart)
- Add `scripts/sync-down.sh` — stops Archon, pulls rclone remote → `~/archon-data/` with destructive-overwrite confirmation (default: restart)
- Both enforce `docker compose down` before sync (SQLite WAL corruption prevention), check deps with install hints, verify rclone remote, support `--dry-run`, and narrate every step

## Commits
- feat(ops): add sync-up.sh and sync-down.sh for cross-machine data sync

## Validation
- `bash -n` syntax check: pass
- `shellcheck`: zero warnings
- Executable bits: set
- `--help` self-documentation: verified
- Missing-tool narration: verified
- Full `validate.sh` suite: 4 passed, 2 skipped (no unit tests or integration tests for bash scripts)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)