### PR TITLE
docs(sync): add cross-machine sync guide with rclone setup and script usage

### DIFF
--- a/.claude/HANDOFF.md
+++ b/.claude/HANDOFF.md
@@ -1,30 +1,41 @@
-# Handoff — Issue #8: sync-up.sh and sync-down.sh
+# Handoff — Issue #9: Write docs/SYNC-BETWEEN-MACHINES.md
 
 ## Goal
-Create two host-run Bash scripts for cross-machine data sync via rclone, enabling the laptop-desktop workflow.
+
+Create a beginner-friendly guide for syncing Archon data between machines using rclone and the sync scripts from issue #8.
 
 ## What Was Done
-- Created `scripts/sync-up.sh` (181 lines) — stops Archon, backs up DB, syncs `~/archon-data/` to rclone remote. Defaults to NOT restarting (operator is leaving this machine).
-- Created `scripts/sync-down.sh` (223 lines) — stops Archon, pulls rclone remote to `~/archon-data/`, restarts by default (operator just arrived). Requires `--yes` or interactive `YES` confirmation before overwriting local data.
-- Both scripts: `set -euo pipefail`, dep checks (docker + rclone with install hints), `RCLONE_REMOTE` fallback chain (shell env, `.env`, `gdrive:archon-data`), remote verification via `rclone listremotes`, `docker compose down` (not stop) before any sync, `--dry-run` passthrough, `--help` self-documentation, narration markers to stderr.
-- All static validation passed: `bash -n`, `shellcheck` (zero warnings), executable bits, `--help` grep checks, missing-tool narration check.
+
+- **Created** `docs/SYNC-BETWEEN-MACHINES.md` (259 lines) — full guide covering:
+  - Prerequisites, "Why sync?", and "How it works" architecture overview
+  - Step-by-step rclone install and Google Drive remote configuration (13-step wizard walkthrough)
+  - Optional `RCLONE_REMOTE` configuration in `.env`
+  - `sync-up.sh` usage with `--restart` and `--dry-run` flags
+  - `sync-down.sh` usage with `--yes`, `--no-restart`, and `--dry-run` flags
+  - `--dry-run` for sync-down documented with prompt interaction, side effects, and recommended low-disruption combo (`--dry-run --yes --no-restart`)
+  - Common scenarios (leaving laptop, arriving at desktop)
+  - "What you should see" output after every procedural step
+  - SQLite WAL constraint explained (WHY, not just WHAT)
+  - One-directional sync warning, destructive overwrite warning, headless OAuth gotcha
+
+- **Updated** `docs/SETUP.md` line 246 — converted "coming soon" plain-text reference to a proper Markdown link
 
 ## Key Decisions
-- Scripts are fully self-contained (no shared lib) — matches project convention where existing scripts share no code.
-- `read_env_key()` uses `grep`+`cut` (not `source .env`) to avoid shell metacharacter issues under `set -u`.
-- rclone flags use array-based approach for shellcheck compliance.
-- sync-up calls `backup.sh` after `docker compose down` (not before) per backup.sh's own usage contract.
+
+- Documented `--dry-run` for sync-down (not in original PRP) after review identified the gap — especially important since sync-down is destructive and users benefit from previewing
+- Noted that `--dry-run` still stops/restarts Archon (script behavior) and recommended the `--dry-run --yes --no-restart` combo for minimal disruption
 
 ## Current State
-- PR created on `feat/issue-8-...` branch, auto-closes #8 on merge.
-- Live rclone sync tests are operator-only (rclone not installed in agent env). Static validation complete.
+
+- All changes committed, PR created, issue #9 closed
+- Validation: 4 passed, 0 failed, 2 skipped (no unit/integration test dirs yet)
 
 ## Next Steps
-1. **Issue #9** — Write `docs/SYNC-BETWEEN-MACHINES.md` (companion doc for these scripts).
-2. **Issue #12** — Create `upgrade.sh` script with backup safety.
-3. **Issue #19** — Define backup consistency model (cp vs sqlite3 .backup).
-4. Remaining docs: #11 (SHARING-WORKFLOWS + DAILY-USE), #13 (UPGRADING + TROUBLESHOOTING).
+
+1. **Issue #12** — Create `upgrade.sh` script with backup safety
+2. **Issue #19** — Define backup consistency model (cp vs sqlite3 .backup)
+3. Remaining docs: #11 (DAILY-USE), #13 (UPGRADING + TROUBLESHOOTING)
 
 ## Issue Tracker
-- #8: closing via this PR
-- #9: open, unblocked — can now reference the delivered scripts
+
+- #9: closed by PR

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -243,7 +243,7 @@ Finally, open `http://localhost:3000` in your browser to access the Archon web U
 - **Daily commands** — starting, stopping, viewing logs, and restarting after a `git pull`;
   see `docs/DAILY-USE.md` (coming soon — issue #11).
 - **Sync data across machines** — use `rclone` and the sync scripts; see
-  `docs/SYNC-BETWEEN-MACHINES.md` (coming soon — issue #9).
+  [`docs/SYNC-BETWEEN-MACHINES.md`](SYNC-BETWEEN-MACHINES.md).
 - **Upgrade the pinned version** — see `docs/UPGRADING.md` (coming soon — issue #13).
 
 ## Something went wrong?

--- a/docs/SYNC-BETWEEN-MACHINES.md
+++ b/docs/SYNC-BETWEEN-MACHINES.md
@@ -1,0 +1,259 @@
+# Sync Between Machines
+
+## What you need before starting
+
+- Archon running on at least one machine (see [docs/SETUP.md](SETUP.md) to get started)
+- [rclone](https://rclone.org/install/) installed on each machine you want to sync
+- A Google Drive account (or any [rclone-supported provider](https://rclone.org/overview/))
+- About 15 minutes for first-time rclone setup per machine
+
+> The sync scripts check for `docker` and `rclone` at startup and print install instructions if either is missing.
+
+## Why sync?
+
+Archon stores all its state — the SQLite database, workspace clones, and logs — in `~/archon-data/` on your machine. If you work across multiple machines (a laptop at a client site and a desktop at home), you need that folder on both. The sync scripts use rclone to copy `~/archon-data/` to and from cloud storage so you can pick up exactly where you left off on any machine.
+
+## How it works
+
+```
+Machine A  →  ./scripts/sync-up.sh  →  Cloud Storage  →  ./scripts/sync-down.sh  →  Machine B
+```
+
+- `sync-up.sh` stops Archon, backs up the database, and copies `~/archon-data/` to the configured rclone remote. Archon stays down after sync (you are done with this machine).
+- `sync-down.sh` stops Archon, downloads from the remote, and restarts Archon (you just arrived).
+- **Archon must be stopped before syncing.** SQLite — the database Archon uses — writes changes to a write-ahead log (WAL) that is only fully checkpointed when all connections close. Copying the database while Archon is running produces a corrupt or inconsistent replica. Both scripts run `docker compose down` automatically before transferring any data.
+
+> **One-directional, not merge.** `rclone sync` makes the destination match the source exactly. If both machines have local changes, whichever ran last wins. Always sync up from the machine you just worked on before syncing down on another — otherwise the older changes are lost.
+
+## Step 1: Install rclone
+
+**macOS:**
+
+```bash
+brew install rclone
+```
+
+**Linux:**
+
+```bash
+sudo apt-get install rclone
+```
+
+For other platforms or the latest version, see the [rclone install guide](https://rclone.org/install/).
+
+Verify the installation:
+
+```bash
+rclone version
+```
+
+**What you should see:**
+
+```
+rclone v1.x.x
+- os/version: ...
+```
+
+The exact version number will vary. What matters is that the command responds without error.
+
+## Step 2: Configure a Google Drive remote
+
+Run the interactive configuration wizard:
+
+```bash
+rclone config
+```
+
+Follow the prompts in order:
+
+1. Type `n` and press Enter to create a new remote.
+2. Enter `gdrive` as the remote name — this matches the default path used by the sync scripts.
+3. When asked for the storage type, type `drive` and press Enter. Do not type a number; numeric positions shift between rclone versions and `drive` is stable.
+4. Press Enter to leave `client_id` blank — uses rclone's built-in OAuth credentials.
+5. Press Enter to leave `client_secret` blank.
+6. When asked for the scope, select `drive.file`. This restricts rclone to files it created — it cannot read your other Google Drive content. In most rclone versions this is listed as option 3, but the number may vary; look for `drive.file` in the description.
+7. Press Enter to accept defaults for `root_folder_id` and `service_account_file`.
+8. When asked to edit advanced config, press Enter (No).
+9. When asked to use auto config, press Enter (Yes). A browser window opens at `http://127.0.0.1:53682/auth` for Google OAuth consent.
+10. Sign in with your Google account and grant rclone the requested access. The browser shows "Success" when complete.
+11. When asked if this is a Shared Drive, press Enter (No).
+12. Confirm the remote summary looks correct and press Enter or type `y` to save.
+13. Type `q` to quit the configuration wizard.
+
+> **Headless or SSH machines.** If you are running rclone on a machine without a browser, skip the auto-config step. On a machine that does have a browser, run `rclone authorize "drive"` and complete the OAuth flow. Copy the token it prints. Back on the headless machine, paste it when rclone prompts for the token during `rclone config`.
+
+Verify the remote was created:
+
+```bash
+rclone listremotes
+```
+
+**What you should see:**
+
+```
+gdrive:
+```
+
+## Step 3: Set RCLONE_REMOTE in .env (optional)
+
+The sync scripts resolve the rclone destination in this order: shell environment variable → `.env` file → built-in default `gdrive:archon-data`. If you named your remote `gdrive` and the folder in Google Drive should be called `archon-data`, the default works and this step is optional.
+
+To use a different remote name or folder path, add this line to your `.env` file:
+
+```
+RCLONE_REMOTE=gdrive:archon-data
+```
+
+Replace `gdrive` with your remote name and `archon-data` with the destination folder path.
+
+> **Do not commit `.env`.** It contains your OAuth token and is `.gitignore`'d by design. The `.env.example` file shows the variable name as a template — never copy credentials into `.env.example`.
+
+## Step 4: Upload your data (sync-up)
+
+Run this command from the repo root:
+
+```bash
+./scripts/sync-up.sh
+```
+
+The script stops Archon, creates a timestamped backup of `archon.db` in `backups/`, and syncs `~/archon-data/` to the remote. Archon stays down after the sync — you are leaving this machine.
+
+**What you should see:**
+
+```
+→ Remote: gdrive:archon-data
+→ Verifying rclone remote 'gdrive:' is configured...
+✓ Remote 'gdrive:' found
+→ Stopping Archon (archon-app) via docker compose down...
+✓ Archon stopped
+→ Creating pre-sync backup...
+✓ Pre-sync backup complete: /path/to/backups/archon-20260518-143022.db
+→ Syncing /Users/you/archon-data → gdrive:archon-data...
+✓ Sync complete in 12s
+
+✓ sync-up complete in 15s → gdrive:archon-data
+```
+
+To stay on this machine and keep working after the sync, add `--restart`:
+
+```bash
+./scripts/sync-up.sh --restart
+```
+
+To preview what would be transferred without transferring anything:
+
+```bash
+./scripts/sync-up.sh --dry-run
+```
+
+## Step 5: Download on another machine (sync-down)
+
+On the destination machine, complete Steps 1–3 first (install rclone, configure the remote, optionally set `RCLONE_REMOTE`). You can also copy `~/.config/rclone/rclone.conf` from the source machine instead of re-running `rclone config` — just do not commit or share this file, as it contains your OAuth token.
+
+Then run:
+
+```bash
+./scripts/sync-down.sh
+```
+
+The script verifies the remote and then asks you to confirm the destructive operation before doing anything:
+
+```
+→ Remote: gdrive:archon-data
+→ Verifying rclone remote 'gdrive:' is configured...
+✓ Remote 'gdrive:' found
+
+WARNING: This will OVERWRITE /Users/you/archon-data with contents of gdrive:archon-data.
+  Local DB: /Users/you/archon-data/archon.db (42M)
+
+Type YES to proceed:
+```
+
+> **Data loss warning.** Typing `YES` replaces everything in `~/archon-data/` with the remote contents. Any local data on this machine that was not first uploaded with `sync-up.sh` will be permanently deleted. If you have unsaved local work, run `sync-up.sh` on this machine before proceeding.
+
+Type `YES` (uppercase, exactly) and press Enter to proceed:
+
+```
+→ Stopping Archon (archon-app) via docker compose down...
+✓ Archon stopped
+→ Ensuring data directory exists: /Users/you/archon-data
+✓ Data directory ready
+→ Syncing gdrive:archon-data → /Users/you/archon-data...
+✓ Sync complete in 18s
+→ Starting Archon...
+→ Validating health...
+archon-app: running (healthy) | Archon API: OK | Workflows loaded: N
+
+✓ sync-down complete in 25s ← gdrive:archon-data
+```
+
+Open `http://localhost:3000` to confirm Archon is running.
+
+To skip the interactive confirmation (for use in scripts or automation):
+
+```bash
+./scripts/sync-down.sh --yes
+```
+
+To download the data without restarting Archon:
+
+```bash
+./scripts/sync-down.sh --no-restart
+```
+
+To preview what sync-down would transfer without actually downloading anything:
+
+```bash
+./scripts/sync-down.sh --dry-run
+```
+
+> **`--dry-run` still triggers the confirmation prompt and still stops/restarts Archon.** Only the rclone transfer is skipped — Archon goes through a full stop-and-restart cycle. To preview with minimal disruption, combine all three flags:
+>
+> ```bash
+> ./scripts/sync-down.sh --dry-run --yes --no-restart
+> ```
+
+**What you should see** (with `--dry-run --yes --no-restart`):
+
+```
+→ Remote: gdrive:archon-data
+→ Verifying rclone remote 'gdrive:' is configured...
+✓ Remote 'gdrive:' found
+→ Stopping Archon (archon-app) via docker compose down...
+✓ Archon stopped
+→ Ensuring data directory exists: /Users/you/archon-data
+✓ Data directory ready
+→ Syncing gdrive:archon-data → /Users/you/archon-data...
+Transferred:        0 B / 0 B, -, 0 B/s, ETA -
+✓ Sync complete in 2s
+
+✓ sync-down complete in 5s ← gdrive:archon-data
+```
+
+No files are transferred. Archon stays down (because of `--no-restart`). Start it again with `docker compose up -d` when you are ready.
+
+## Common scenarios
+
+### Leaving for the day (laptop → cloud)
+
+You are done working on your laptop and want the data available on your desktop.
+
+```bash
+./scripts/sync-up.sh
+```
+
+Archon stops, data uploads, Archon stays down. The laptop is safe to close.
+
+### Arriving at another machine (cloud → desktop)
+
+You are at your desktop and want to continue where you left off on your laptop.
+
+```bash
+./scripts/sync-down.sh
+```
+
+Confirm the overwrite with `YES`. Data downloads and Archon starts automatically. Open `http://localhost:3000` when the script finishes.
+
+## Something went wrong?
+
+See [`docs/TROUBLESHOOTING.md`](TROUBLESHOOTING.md) for common errors and fixes.


### PR DESCRIPTION
## Summary

- Create `docs/SYNC-BETWEEN-MACHINES.md` — beginner-friendly guide covering rclone installation, Google Drive remote configuration, `sync-up.sh` and `sync-down.sh` usage with all flags, SQLite WAL constraint explanation, `--dry-run` side-effect documentation, and common sync scenarios
- Update `docs/SETUP.md` "Next steps" cross-reference from "coming soon" placeholder to a proper Markdown link

Closes #9

## Test plan

- [x] File exists and is under 500 lines (259 lines)
- [x] All required sections present (prerequisites, troubleshooting link, sync-up, sync-down, SQLite, expected output, rclone config, Google Drive)
- [x] No hardcoded secrets or credentials
- [x] SETUP.md cross-reference resolves correctly
- [x] `validate.sh` passes (4 passed, 0 failed, 2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)