### PR TITLE
docs(guides): add daily-use and workflow-sharing guides

### DIFF
--- a/.claude/HANDOFF.md
+++ b/.claude/HANDOFF.md
@@ -1,41 +1,47 @@
-# Handoff — Issue #9: Write docs/SYNC-BETWEEN-MACHINES.md
+# Handoff — Issue #11: Write docs/SHARING-WORKFLOWS.md and docs/DAILY-USE.md
 
 ## Goal
 
-Create a beginner-friendly guide for syncing Archon data between machines using rclone and the sync scripts from issue #8.
+Create two day-to-day operation guides for developers who have completed initial setup: a workflow sharing guide and a daily operations guide.
 
 ## What Was Done
 
-- **Created** `docs/SYNC-BETWEEN-MACHINES.md` (259 lines) — full guide covering:
-  - Prerequisites, "Why sync?", and "How it works" architecture overview
-  - Step-by-step rclone install and Google Drive remote configuration (13-step wizard walkthrough)
-  - Optional `RCLONE_REMOTE` configuration in `.env`
-  - `sync-up.sh` usage with `--restart` and `--dry-run` flags
-  - `sync-down.sh` usage with `--yes`, `--no-restart`, and `--dry-run` flags
-  - `--dry-run` for sync-down documented with prompt interaction, side effects, and recommended low-disruption combo (`--dry-run --yes --no-restart`)
-  - Common scenarios (leaving laptop, arriving at desktop)
-  - "What you should see" output after every procedural step
-  - SQLite WAL constraint explained (WHY, not just WHAT)
-  - One-directional sync warning, destructive overwrite warning, headless OAuth gotcha
+- **Created** `docs/SHARING-WORKFLOWS.md` (136 lines) — team git workflow for sharing custom workflows:
+  - Prerequisites, how sharing works (git-based model), getting workflows (pull → restart → verify)
+  - Contributing workflows (three methods, all referencing WORKFLOW-OVERLAY.md for authoring details)
+  - Filename override behavior (same-name precedence, `archon-` prefix convention, stub suppression)
+  - CLI vs. Web UI listing caveat (SQLite vs. YAML, issue #30 transparency)
+  - 89% save stall documented in troubleshooting section
 
-- **Updated** `docs/SETUP.md` line 246 — converted "coming soon" plain-text reference to a proper Markdown link
+- **Created** `docs/DAILY-USE.md` (279 lines) — routine operations guide:
+  - Start/stop Archon, health checks (`health.sh` + `docker compose ps`), log streaming
+  - Listing all 10 built-in workflows with description table
+  - Running workflows from CLI with examples (`archon-assist`, `archon-fix-github-issue`) and flag reference
+  - Running workflows from Web UI (`localhost:3000`, workflows page, builder)
+  - Checking status, resuming failed runs, approve/reject gates
+  - Viewing results (terminal streaming, artifacts, PR URLs, worktree isolation)
+  - `archon doctor` validation, restart patterns (restart vs. down+up)
+  - `docker compose exec app` prefix pattern explained for zero-Docker-knowledge audience
+
+- **Updated** `docs/SETUP.md` line 244 — replaced "coming soon — issue #11" with proper Markdown link to DAILY-USE.md
 
 ## Key Decisions
 
-- Documented `--dry-run` for sync-down (not in original PRP) after review identified the gap — especially important since sync-down is destructive and users benefit from previewing
-- Noted that `--dry-run` still stops/restarts Archon (script behavior) and recommended the `--dry-run --yes --no-restart` combo for minimal disruption
+- SHARING-WORKFLOWS.md delegates all overlay technical details to WORKFLOW-OVERLAY.md — focuses strictly on the team git collaboration workflow
+- Used generic `<tag>` placeholder in `docker compose ps` example output to avoid stale version references
+- Documented issue #30 (git-pull workflow sharing unverified) transparently without claiming verified status
 
 ## Current State
 
-- All changes committed, PR created, issue #9 closed
-- Validation: 4 passed, 0 failed, 2 skipped (no unit/integration test dirs yet)
+- All changes committed, PR created, issue #11 closed
+- Validation: 4 passed, 0 failed, 2 skipped
 
 ## Next Steps
 
-1. **Issue #12** — Create `upgrade.sh` script with backup safety
-2. **Issue #19** — Define backup consistency model (cp vs sqlite3 .backup)
-3. Remaining docs: #11 (DAILY-USE), #13 (UPGRADING + TROUBLESHOOTING)
+1. **Issue #13** — Create `docs/UPGRADING.md` (version bump procedure with backup safety)
+2. **TROUBLESHOOTING.md** — all 5 docs now link to this planned file; creating it would resolve dead links
+3. **Issue #30** — smoke-test git-pull workflow sharing end-to-end
 
 ## Issue Tracker
 
-- #9: closed by PR
+- #11: closed by PR

--- a/docs/DAILY-USE.md
+++ b/docs/DAILY-USE.md
@@ -1,0 +1,279 @@
+# Daily Use
+
+## What you need before starting
+
+- Completed [docs/SETUP.md](SETUP.md) — Archon container image pulled, `.env` configured with a valid `CLAUDE_CODE_OAUTH_TOKEN`
+- Docker Desktop (or Docker Engine) running on your machine
+
+> All commands in this guide run from the repo root directory (`archon-setup/`).
+
+## Starting Archon
+
+Start Archon in the background:
+
+```bash
+docker compose up -d
+```
+
+`docker compose up -d` starts the container in detached mode (background). Docker does not pull a new image on this command — it uses the pinned image tag already on disk.
+
+**What you should see:**
+
+```
+✔ Container archon-app  Started
+```
+
+Archon's healthcheck has a `start_period: 15s` — wait about 20 seconds before checking health. To stream startup logs in real time while waiting, run `docker compose logs -f app` in a separate terminal.
+
+## Stopping Archon
+
+```bash
+docker compose down
+```
+
+`docker compose down` stops the container and removes it. All data is stored in `~/archon-data/` on your machine — stopping the container does not delete anything. Use `docker compose down` before running sync scripts, before upgrading, or to free resources.
+
+To stop without removing the container (preserves it for faster restart with `docker compose start`):
+
+```bash
+docker compose stop
+```
+
+## Checking health
+
+After starting, run the health check script to confirm everything is working:
+
+```bash
+./scripts/health.sh
+```
+
+The script checks three things: the container is running, the `/api/health` endpoint responds, and workflow count (informational). The first two must pass.
+
+**What you should see:**
+
+```
+archon-app: running (healthy) | Archon API: OK | Workflows loaded: N
+```
+
+If `Archon API: unreachable`, wait a few more seconds and retry — the healthcheck has a 15-second start period before the container is marked `healthy`.
+
+You can also check container status directly:
+
+```bash
+docker compose ps
+```
+
+**What you should see:**
+
+```
+NAME          IMAGE                              STATUS
+archon-app    ghcr.io/coleam00/archon:<tag>      Up ... (healthy)
+```
+
+The `<tag>` matches the pinned version in `docker-compose.yml`.
+
+## Viewing logs
+
+Stream logs from the Archon container:
+
+```bash
+docker compose logs -f app
+```
+
+`-f` tails the log in real time. Press `Ctrl+C` to stop streaming. Remove `-f` to print existing logs and exit.
+
+**What you should see on a healthy startup:**
+
+```
+archon-app  | [INFO] Archon started
+archon-app  | [INFO] Listening on port 3000
+```
+
+Errors appear as `[ERROR]` lines. If Archon fails to start, the container logs are the first place to look.
+
+## Listing available workflows
+
+List every workflow available — Archon's 10 built-ins plus any custom workflows in `.archon/workflows/`:
+
+```bash
+docker compose exec app archon workflow list
+```
+
+`docker compose exec app` sends the command into the running container. Archon runs inside Docker, so all Archon CLI commands use this prefix.
+
+**What you should see:** A table of workflow names and descriptions. Archon's built-in workflows:
+
+| Workflow | Description |
+|---|---|
+| `archon-assist` | Answer questions about the codebase |
+| `archon-fix-github-issue` | Investigate and fix a GitHub issue |
+| `archon-idea-to-pr` | Turn a plain-language idea into a pull request |
+| `archon-plan-to-pr` | Turn a structured plan into a pull request |
+| `archon-feature-development` | End-to-end feature development |
+| `archon-smart-pr-review` | Focused, targeted PR review |
+| `archon-comprehensive-pr-review` | In-depth PR review with full context |
+| `archon-architect` | Architectural analysis and design recommendations |
+| `archon-ralph-dag` | Build a directed-acyclic graph of tasks |
+| `archon-resolve-conflicts` | Resolve git merge conflicts |
+
+These are available even when `.archon/workflows/` is empty — they ship inside the Docker image. For details on how Archon resolves custom workflows alongside built-ins, see [docs/WORKFLOW-OVERLAY.md](WORKFLOW-OVERLAY.md).
+
+## Running a workflow from the CLI
+
+```bash
+docker compose exec app archon workflow run <name> "<message>"
+```
+
+Examples:
+
+```bash
+# Ask a question about the codebase
+docker compose exec app archon workflow run archon-assist "What does the orchestrator do?"
+
+# Fix a GitHub issue with an isolated worktree branch
+docker compose exec app archon workflow run archon-fix-github-issue --branch fix/login-crash "#142"
+```
+
+Archon streams AI reasoning to the terminal as it runs. Use `--quiet` to suppress streaming output or `--verbose` for tool-level events.
+
+Key flags:
+
+| Flag | Description |
+|---|---|
+| `--branch <name>` | Create an isolated git worktree on this branch (default behavior: runs in isolated worktree) |
+| `--no-worktree` | Run directly in the live checkout instead of an isolated worktree |
+| `--verbose` | Stream tool-level events (file reads, writes, shell commands) |
+| `--quiet` | Suppress streaming output; show only the final result |
+| `--resume` | Resume an interrupted run, skipping already-completed nodes |
+
+> **Worktree isolation is on by default.** Workflows run in isolated git worktrees at `~/.archon/workspaces/` inside the container. This keeps experiments off your main branch. Use `--no-worktree` only when you want the workflow to modify your live working directory.
+
+Workflow name matching is fuzzy: exact → case-insensitive → suffix → substring. For example, `archon workflow run assist` resolves to `archon-assist`.
+
+## Running a workflow from the Web UI
+
+Open `http://localhost:3000` in your browser.
+
+> If you changed the `PORT` variable in `.env`, use that port number: `http://localhost:<PORT>`.
+
+The Web UI provides a chat-style interface for working with Archon. Key pages:
+
+- **`/workflows`** — lists workflows that have a SQLite record (see note in [Listing available workflows](#listing-available-workflows))
+- **`/workflows/builder`** — create or edit a workflow using the visual builder
+- **`+ New Workflow`** button on the Workflows page — shortcut to the builder
+
+## Checking workflow status
+
+Show all currently running workflow runs:
+
+```bash
+docker compose exec app archon workflow status
+```
+
+**What you should see:** A table of active runs with run IDs, workflow names, and status. Empty output means nothing is currently running.
+
+To resume a run that was interrupted:
+
+```bash
+docker compose exec app archon workflow resume <run-id>
+```
+
+To approve or reject a workflow at an approval gate:
+
+```bash
+docker compose exec app archon workflow approve <run-id>
+docker compose exec app archon workflow reject <run-id>
+```
+
+For container-level logs when a run is missing from `status`:
+
+```bash
+docker compose logs -f app
+```
+
+## Viewing results
+
+CLI runs stream output to the terminal in real time. The final result prints when the workflow completes.
+
+Multi-step workflows pass output between steps using artifact files (for example, `investigation.md` or `implementation.md`). These are stored inside the workflow's worktree directory under `~/archon-data/` on your host.
+
+Workflows that create pull requests print the PR URL on completion:
+
+```
+✓ Pull request created: https://github.com/<org>/<repo>/pull/<number>
+```
+
+Archon stores all workflow state in `~/archon-data/archon.db` (SQLite). Active worktrees live under `~/archon-data/`.
+
+To list active worktrees or clean up stale ones:
+
+```bash
+docker compose exec app archon isolation list
+docker compose exec app archon isolation cleanup
+```
+
+## Validating your setup
+
+Run Archon's built-in diagnostic:
+
+```bash
+docker compose exec app archon doctor
+```
+
+`archon doctor` checks: binary spawn, authentication, database connectivity, workspace writability, and bundled defaults.
+
+**What you should see:**
+
+```
+✓ binary spawn
+✓ authentication
+✓ database
+✓ workspace write
+✓ bundled defaults
+```
+
+Any `✗` line indicates a specific failure. An authentication failure usually means the OAuth token in `.env` is expired — re-run `./scripts/setup-oauth.sh` to refresh it.
+
+## Restarting after configuration changes
+
+After changes that do not require a full stop — for example, a `git pull` that added new workflows, an edit to `.env`, or a change to `.archon/config.yaml`:
+
+```bash
+docker compose restart app
+```
+
+`restart` stops and starts the container in place. It is faster than a full `down`/`up` cycle and does not re-pull the image.
+
+After changes that require a full stop — for example, before running a sync script or after modifying volume mounts in `docker-compose.yml`:
+
+```bash
+docker compose down
+docker compose up -d
+```
+
+`down` removes the container. `up -d` recreates it from the current `docker-compose.yml`.
+
+## Something went wrong?
+
+See [docs/TROUBLESHOOTING.md](TROUBLESHOOTING.md) for common errors and fixes.
+
+### Save stalling at ~89% in the workflow builder
+
+The most common operational issue. When the OAuth token in `.env` is expired, the workflow builder stalls mid-save. The YAML file is written to `.archon/workflows/` (visible in `git status`) but the SQLite record is not written — so the workflow does not appear in the Workflows Web UI page.
+
+To fix: run `./scripts/setup-oauth.sh` to refresh the token, then retry the save in the builder.
+
+### Container not starting
+
+Run `docker compose logs app` to see the error. Common causes:
+
+- Port 3000 already in use — change `PORT` in `.env` and restart
+- `~/archon-data/` owned by root — run `sudo chown -R $USER ~/archon-data` and restart
+
+### API health check failing after startup
+
+Wait 20 seconds and retry `./scripts/health.sh`. The healthcheck has a `start_period: 15s` before the container transitions to `healthy`. If it remains unhealthy, check `docker compose logs app` for error lines.
+
+### Workflow not found
+
+Run `docker compose exec app archon workflow list` to confirm the name. Name matching is fuzzy (suffix and substring), but the workflow must exist on disk or in the SQLite database. If a custom workflow is missing, confirm the YAML file is in `.archon/workflows/` and the container was restarted after the file was added.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -241,7 +241,7 @@ Finally, open `http://localhost:3000` in your browser to access the Archon web U
   how the overlay model works, how to create workflows in the UI or by hand, and how to
   share them with the team via git.
 - **Daily commands** — starting, stopping, viewing logs, and restarting after a `git pull`;
-  see `docs/DAILY-USE.md` (coming soon — issue #11).
+  see [`docs/DAILY-USE.md`](DAILY-USE.md).
 - **Sync data across machines** — use `rclone` and the sync scripts; see
   [`docs/SYNC-BETWEEN-MACHINES.md`](SYNC-BETWEEN-MACHINES.md).
 - **Upgrade the pinned version** — see `docs/UPGRADING.md` (coming soon — issue #13).

--- a/docs/SHARING-WORKFLOWS.md
+++ b/docs/SHARING-WORKFLOWS.md
@@ -1,0 +1,136 @@
+# Sharing Workflows
+
+## What you need before starting
+
+- Archon running on your machine (see [docs/SETUP.md](SETUP.md) if you have not completed first-time setup)
+- This repository cloned to your machine
+- Git configured with your name and email (`git config user.name` and `git config user.email`)
+
+> This guide focuses on the team git workflow for sharing custom workflows. For the full technical details of how Archon discovers and overrides workflows — including the three-layer resolution model and container path layout — see [docs/WORKFLOW-OVERLAY.md](WORKFLOW-OVERLAY.md).
+
+## How workflow sharing works
+
+Workflow YAML files live in `.archon/workflows/` inside this repo. Because that directory is git-tracked, sharing a workflow with the team is the same as sharing any code change: commit the file, push, and teammates pull.
+
+After a teammate runs `git pull`, they restart the Archon container:
+
+```bash
+docker compose restart app
+```
+
+Archon reads `.archon/workflows/` through a bind mount — the directory on your machine is directly visible inside the container. After restart, any new YAML files are available to the Archon CLI. See [docs/WORKFLOW-OVERLAY.md](WORKFLOW-OVERLAY.md) for the full overlay resolution model.
+
+> **CLI vs. Web UI listing.** The Archon CLI (`archon workflow list`) discovers workflows from YAML files on disk. The Workflows page at `http://localhost:3000/workflows` reads from Archon's SQLite database — a YAML file placed on disk via `git pull` appears in the CLI but may not appear in the Web UI until it is opened and re-saved through the builder. This behavior is under investigation in issue #30.
+
+## Getting workflows from your team
+
+When a teammate pushes new or updated workflows:
+
+1. Pull the latest changes:
+
+```bash
+git pull
+```
+
+**What you should see:** Git lists the files that changed. New or updated `.yaml` files under `.archon/workflows/` confirm the workflow was received.
+
+2. Restart the container to pick up the new files:
+
+```bash
+docker compose restart app
+```
+
+**What you should see:**
+
+```
+✔ Container archon-app  Started
+```
+
+The restart takes about 5 seconds. Archon reads the updated overlay on startup.
+
+3. Confirm the workflow is available:
+
+```bash
+docker compose exec app archon workflow list
+```
+
+**What you should see:** The new workflow name appears in the list.
+
+> **Workflow appears in CLI but not in the Workflows Web UI page?** This is expected — the UI reads from SQLite, not YAML files. The CLI is the reliable way to confirm a git-pulled workflow is loaded. See [Something went wrong?](#something-went-wrong) for more detail.
+
+## Contributing a workflow
+
+There are three ways to author a workflow: the Archon workflow builder UI, hand-written YAML, or Claude Code. For detailed authoring instructions, see [docs/WORKFLOW-OVERLAY.md — Three ways to create or modify a workflow](WORKFLOW-OVERLAY.md#three-ways-to-create-or-modify-a-workflow).
+
+After authoring a workflow by any method, share it with the team by committing and pushing the YAML file:
+
+```bash
+git status                          # confirm the new file appears under .archon/workflows/
+git add .archon/workflows/
+git commit -m "feat(workflow): add <name> workflow"
+git push
+```
+
+**What you should see:** The push succeeds. Teammates who run `git pull` followed by `docker compose restart app` will have the workflow available in their CLI.
+
+> **`description:` is required on every workflow YAML.** Archon's skill discovery system uses this field. A workflow without `description:` may not appear in tool lists or the Web UI.
+
+> **Do not place secrets in `.archon/workflows/` or `.archon/commands/`.** Both directories are git-tracked. Credentials belong in `.env`, which is `.gitignore`'d.
+
+### If the workflow was built in the Archon UI
+
+After saving in the builder, the YAML file appears in `.archon/workflows/` on your host machine. Stage and commit it:
+
+```bash
+git status                          # verify the file is listed as untracked
+git diff .archon/workflows/         # review the YAML before committing
+git add .archon/workflows/
+git commit -m "feat(workflow): add <name> workflow"
+git push
+```
+
+> **Save stalling at ~89%?** The OAuth token in `.env` is expired. The YAML file is written to disk but the SQLite record is not written — the workflow appears in `git status` but not in the Workflows Web UI. Refresh the token by running `./scripts/setup-oauth.sh`, then retry the save. See [Something went wrong?](#something-went-wrong) for details.
+
+## Filename override behavior
+
+A file in `.archon/workflows/` with the same name as one of Archon's bundled defaults takes precedence — the custom version runs, the bundled one is ignored.
+
+Use **distinct filenames** for new custom workflows to avoid accidental shadowing. Archon's built-in workflows use names starting with `archon-` (for example, `archon-assist`, `archon-fix-github-issue`). A name that does not start with `archon-` avoids collisions.
+
+To intentionally suppress a built-in, create a same-named stub:
+
+```yaml
+description: Disabled — suppresses the bundled default of the same name.
+steps: []
+```
+
+Restart and commit:
+
+```bash
+docker compose restart app
+git add .archon/workflows/<filename>.yaml
+git commit -m "chore(workflow): suppress built-in <filename>"
+git push
+```
+
+**What you should see:** After the restart, `docker compose exec app archon workflow list` no longer shows the suppressed workflow. The stub override takes its place.
+
+For the full overlay resolution order and instructions on restoring a suppressed default, see [docs/WORKFLOW-OVERLAY.md](WORKFLOW-OVERLAY.md).
+
+## Something went wrong?
+
+See [docs/TROUBLESHOOTING.md](TROUBLESHOOTING.md) for common errors and fixes.
+
+### Workflow not appearing after git pull + restart
+
+If the workflow appears in `docker compose exec app archon workflow list` but not in the Workflows Web UI, this is expected — the UI reads from SQLite while the CLI reads YAML files. Issue #30 is tracking the gap.
+
+If the workflow does not appear in the CLI either, check:
+
+1. The YAML file exists on disk: `ls .archon/workflows/`
+2. The container was restarted after the pull: `docker compose restart app`
+3. The YAML has a `description:` field: open the file and check the top-level keys
+
+### Save stalling at ~89% in the workflow builder
+
+The OAuth token in `.env` is expired. The YAML file is written to disk (visible in `git status`) but the SQLite record is not written, so the workflow does not appear in the Workflows UI page. Run `./scripts/setup-oauth.sh` to refresh the token, then retry the save in the builder.


### PR DESCRIPTION
## Summary

- docs(guides): add daily-use and workflow-sharing guides

**SHARING-WORKFLOWS.md** (136 lines) — team git workflow for sharing custom workflows: pull → restart → verify model, contributing via three methods, filename override behavior, CLI vs. Web UI listing caveat (issue #30), 89% save stall troubleshooting.

**DAILY-USE.md** (279 lines) — routine operations: start/stop, health checks, logs, listing all 10 built-in workflows, running from CLI (with examples and flag table), running from Web UI, checking status/resuming/approving, viewing results, `archon doctor` validation, restart patterns.

**SETUP.md** — replaced "coming soon — issue #11" placeholder with proper Markdown link to DAILY-USE.md.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)