### PR TITLE
feat(ops): add upgrade.sh for safe Archon image version upgrades

### DIFF
--- a/.claude/HANDOFF.md
+++ b/.claude/HANDOFF.md
@@ -1,47 +1,39 @@
-# Handoff — Issue #11: Write docs/SHARING-WORKFLOWS.md and docs/DAILY-USE.md
+# Handoff — Issue #12: Create upgrade.sh with backup safety
 
 ## Goal
 
-Create two day-to-day operation guides for developers who have completed initial setup: a workflow sharing guide and a daily operations guide.
+Create `scripts/upgrade.sh` that safely upgrades the pinned Archon Docker image
+version with pre-upgrade SQLite backup and post-upgrade health validation.
 
 ## What Was Done
 
-- **Created** `docs/SHARING-WORKFLOWS.md` (136 lines) — team git workflow for sharing custom workflows:
-  - Prerequisites, how sharing works (git-based model), getting workflows (pull → restart → verify)
-  - Contributing workflows (three methods, all referencing WORKFLOW-OVERLAY.md for authoring details)
-  - Filename override behavior (same-name precedence, `archon-` prefix convention, stub suppression)
-  - CLI vs. Web UI listing caveat (SQLite vs. YAML, issue #30 transparency)
-  - 89% save stall documented in troubleshooting section
-
-- **Created** `docs/DAILY-USE.md` (279 lines) — routine operations guide:
-  - Start/stop Archon, health checks (`health.sh` + `docker compose ps`), log streaming
-  - Listing all 10 built-in workflows with description table
-  - Running workflows from CLI with examples (`archon-assist`, `archon-fix-github-issue`) and flag reference
-  - Running workflows from Web UI (`localhost:3000`, workflows page, builder)
-  - Checking status, resuming failed runs, approve/reject gates
-  - Viewing results (terminal streaming, artifacts, PR URLs, worktree isolation)
-  - `archon doctor` validation, restart patterns (restart vs. down+up)
-  - `docker compose exec app` prefix pattern explained for zero-Docker-knowledge audience
-
-- **Updated** `docs/SETUP.md` line 244 — replaced "coming soon — issue #11" with proper Markdown link to DAILY-USE.md
+- **Created** `scripts/upgrade.sh` (212 lines, 12 functions):
+  - `stop_archon()` — mirrors sync-up.sh exactly; handles already-stopped gracefully
+  - `run_backup()` — calls backup.sh, captures stdout as backup path; **hard-fails** if DB missing (unlike sync-up.sh which tolerates missing DB — you can't upgrade what was never set up)
+  - `update_compose_tag()` / `revert_compose_tag()` — portable sed via mktemp/mv (no `sed -i`); update verifies with grep-q after write
+  - `pull_image()` — reverts compose file on pull failure (safe: no data touched before pull)
+  - `validate_health()` — delegates to health.sh, returns 1 without aborting
+  - `print_rollback_instructions()` — numbered 5-step guide with exact backup path and old tag embedded
+  - `main()` — full flow with `--dry-run`, idempotent same-version check, explicit exit codes (0/1/2)
 
 ## Key Decisions
 
-- SHARING-WORKFLOWS.md delegates all overlay technical details to WORKFLOW-OVERLAY.md — focuses strictly on the team git collaboration workflow
-- Used generic `<tag>` placeholder in `docker compose ps` example output to avoid stale version references
-- Documented issue #30 (git-pull workflow sharing unverified) transparently without claiming verified status
+- **No auto-rollback on health failure** — the new Archon version may have modified DB schema during startup; auto-revert without DB restore would leave inconsistent state. Rollback instructions printed instead (exit code 2).
+- **Revert on pull failure only** — pull failure means no new image fetched and no data touched; safe to revert compose file. Contrast with health failure where data may already be modified.
+- **Hard backup failure** — unlike sync-up.sh which tolerates a missing DB for first-sync, upgrade.sh exits on backup failure. You cannot safely upgrade without a backup.
 
 ## Current State
 
-- All changes committed, PR created, issue #11 closed
+- `scripts/upgrade.sh` committed, PR created, issue #12 closed
 - Validation: 4 passed, 0 failed, 2 skipped
+- Shellcheck: 0 warnings
 
 ## Next Steps
 
-1. **Issue #13** — Create `docs/UPGRADING.md` (version bump procedure with backup safety)
-2. **TROUBLESHOOTING.md** — all 5 docs now link to this planned file; creating it would resolve dead links
-3. **Issue #30** — smoke-test git-pull workflow sharing end-to-end
+1. **Issue #13** — Create `docs/UPGRADING.md` and `docs/TROUBLESHOOTING.md`
+2. **Issue #19** — Define backup consistency model (cp vs sqlite3 .backup) — may affect upgrade.sh's pre-upgrade backup strategy
+3. **Issue #30** — Verify git-pull workflow sharing end-to-end
 
 ## Issue Tracker
 
-- #11: closed by PR
+- #12: closed by PR

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+readonly COMPOSE_FILE="${PROJECT_DIR}/docker-compose.yml"
+readonly CONTAINER_NAME="archon-app"
+readonly BACKUP_SCRIPT="${SCRIPT_DIR}/backup.sh"
+readonly HEALTH_SCRIPT="${SCRIPT_DIR}/health.sh"
+readonly IMAGE_PREFIX="ghcr.io/coleam00/archon"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <new-tag> [OPTIONS]
+
+Safely upgrades the pinned Archon Docker image version.
+
+Flow: stop Archon → backup database → update tag in docker-compose.yml →
+      docker compose pull → docker compose up -d → validate health
+
+Positional argument:
+  <new-tag>    GHCR image tag to upgrade to (e.g., 0.5.0)
+
+Options:
+  --dry-run    Show what would happen without modifying anything
+  -h, --help   Show this help and exit
+
+Exit codes:
+  0  Upgrade successful
+  1  Failure — upgrade aborted; docker-compose.yml reverted if pull failed
+  2  Health check failed — upgrade applied but Archon is not responding;
+     rollback instructions are printed (restore backup before reverting tag)
+EOF
+}
+
+check_deps() {
+  local missing=0
+  for cmd in docker sed grep; do
+    if ! command -v "${cmd}" &>/dev/null; then
+      echo "✗ Required tool not found: ${cmd}" >&2
+      case "${cmd}" in
+        docker) echo "  Install Docker: https://docs.docker.com/get-docker/" >&2 ;;
+        sed)    echo "  sed ships with macOS and most Linux distros" >&2 ;;
+        grep)   echo "  grep ships with macOS and most Linux distros" >&2 ;;
+      esac
+      missing=1
+    fi
+  done
+  if [[ "${missing}" -ne 0 ]]; then
+    exit 1
+  fi
+}
+
+extract_current_tag() {
+  local line tag
+  line=$(grep "image: ${IMAGE_PREFIX}:" "${COMPOSE_FILE}" || true)
+  if [[ -z "${line}" ]]; then
+    echo "✗ Could not find image line in ${COMPOSE_FILE}" >&2
+    echo "  Expected: image: ${IMAGE_PREFIX}:<tag>" >&2
+    exit 1
+  fi
+  tag="${line##*:}"
+  printf '%s\n' "${tag}"
+}
+
+stop_archon() {
+  echo "→ Stopping Archon (${CONTAINER_NAME}) via docker compose down..." >&2
+  local running
+  running=$(docker compose -f "${COMPOSE_FILE}" ps -q 2>/dev/null || true)
+  if [[ -z "${running}" ]]; then
+    echo "✓ Archon already stopped" >&2
+    return 0
+  fi
+  docker compose -f "${COMPOSE_FILE}" down
+  echo "✓ Archon stopped" >&2
+}
+
+run_backup() {
+  echo "→ Creating pre-upgrade backup..." >&2
+  local backup_path
+  if ! backup_path=$("${BACKUP_SCRIPT}"); then
+    echo "✗ Backup failed — cannot proceed without a backup" >&2
+    exit 1
+  fi
+  echo "✓ Pre-upgrade backup complete: ${backup_path}" >&2
+  printf '%s\n' "${backup_path}"
+}
+
+update_compose_tag() {
+  local new_tag="$1"
+  local tmpfile
+  tmpfile=$(mktemp)
+  echo "→ Updating image tag in docker-compose.yml → ${new_tag}" >&2
+  sed "s|image: ${IMAGE_PREFIX}:.*|image: ${IMAGE_PREFIX}:${new_tag}|" \
+    "${COMPOSE_FILE}" > "${tmpfile}" && mv "${tmpfile}" "${COMPOSE_FILE}"
+  if ! grep -q "image: ${IMAGE_PREFIX}:${new_tag}" "${COMPOSE_FILE}"; then
+    echo "✗ Tag update failed — ${IMAGE_PREFIX}:${new_tag} not found after replacement" >&2
+    exit 1
+  fi
+  echo "✓ Image tag updated → ${new_tag}" >&2
+}
+
+revert_compose_tag() {
+  local old_tag="$1"
+  local tmpfile
+  tmpfile=$(mktemp)
+  echo "→ Reverting image tag in docker-compose.yml → ${old_tag}" >&2
+  sed "s|image: ${IMAGE_PREFIX}:.*|image: ${IMAGE_PREFIX}:${old_tag}|" \
+    "${COMPOSE_FILE}" > "${tmpfile}" && mv "${tmpfile}" "${COMPOSE_FILE}"
+  echo "✓ Image tag reverted → ${old_tag}" >&2
+}
+
+pull_image() {
+  local old_tag="$1"
+  echo "→ Pulling new Archon image from GHCR..." >&2
+  if ! docker compose -f "${COMPOSE_FILE}" pull; then
+    echo "✗ docker compose pull failed" >&2
+    revert_compose_tag "${old_tag}"
+    exit 1
+  fi
+  echo "✓ Image pulled successfully" >&2
+}
+
+start_archon() {
+  echo "→ Starting Archon..." >&2
+  docker compose -f "${COMPOSE_FILE}" up -d
+  echo "✓ Archon started" >&2
+}
+
+validate_health() {
+  echo "→ Validating health..." >&2
+  "${HEALTH_SCRIPT}" || return 1
+}
+
+print_rollback_instructions() {
+  local old_tag="$1"
+  local backup_path="$2"
+  cat >&2 <<EOF
+
+✗ Health check failed after upgrade. Manual rollback steps:
+
+  1. Stop Archon:
+       docker compose down
+
+  2. Restore the database backup:
+       cp ${backup_path} ~/archon-data/archon.db
+
+  3. Revert the image tag in docker-compose.yml back to ${old_tag}:
+       Open docker-compose.yml and change the image line to:
+       image: ${IMAGE_PREFIX}:${old_tag}
+
+  4. Restart Archon:
+       docker compose up -d
+
+  5. Verify health:
+       scripts/health.sh
+
+WARNING: Always restore the backup (step 2) before reverting the image tag
+(step 3). The new version may have modified the database schema on startup.
+You can re-run scripts/health.sh manually if Archon needs more startup time.
+EOF
+}
+
+main() {
+  local new_tag="" dry_run=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)  usage; exit 0 ;;
+      --dry-run)  dry_run=true ;;
+      -*)         echo "✗ Unknown flag: $1" >&2; usage >&2; exit 1 ;;
+      *)          new_tag="$1" ;;
+    esac
+    shift
+  done
+  if [[ -z "${new_tag}" ]]; then
+    echo "✗ Missing required argument: <new-tag>" >&2
+    usage >&2
+    exit 1
+  fi
+  check_deps
+  local old_tag
+  old_tag=$(extract_current_tag)
+  if [[ "${old_tag}" == "${new_tag}" ]]; then
+    echo "✓ Already running ${new_tag} — nothing to do" >&2
+    exit 0
+  fi
+  echo "→ Upgrading Archon: ${old_tag} → ${new_tag}" >&2
+  if [[ "${dry_run}" == "true" ]]; then
+    echo "  [dry-run] Would stop Archon (${CONTAINER_NAME})" >&2
+    echo "  [dry-run] Would back up ~/archon-data/archon.db" >&2
+    echo "  [dry-run] Would update docker-compose.yml: ${old_tag} → ${new_tag}" >&2
+    echo "  [dry-run] Would pull ${IMAGE_PREFIX}:${new_tag}" >&2
+    echo "  [dry-run] Would restart Archon and validate health via scripts/health.sh" >&2
+    exit 0
+  fi
+  stop_archon
+  local backup_path
+  backup_path=$(run_backup)
+  update_compose_tag "${new_tag}"
+  pull_image "${old_tag}"
+  start_archon
+  if ! validate_health; then
+    print_rollback_instructions "${old_tag}" "${backup_path}"
+    exit 2
+  fi
+  echo "" >&2
+  echo "✓ Upgrade complete: ${old_tag} → ${new_tag}" >&2
+  echo "  Backup: ${backup_path}" >&2
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Add `scripts/upgrade.sh` implementing the full upgrade workflow: stop → backup → bump image tag → pull → restart → health check
- On health check failure, prints explicit numbered rollback instructions (backup path + old tag embedded) rather than auto-rolling back — the new Archon version may have modified the database schema during startup
- Supports `--dry-run` (planned actions without executing) and exits idempotently if the requested version is already running
- Reverts `docker-compose.yml` automatically if `docker compose pull` fails (safe: no data has been touched at that point)
- Passes shellcheck 0.11.0 with zero warnings; all functions under 50 lines; portable sed via mktemp/mv (no `sed -i`)

## Test plan

- [ ] `./scripts/upgrade.sh --help` — usage printed
- [ ] `./scripts/upgrade.sh 0.3.6 --dry-run` — shows "already running, nothing to do" (idempotent)
- [ ] `./scripts/upgrade.sh 0.5.0 --dry-run` — shows planned actions, nothing modified
- [ ] `shellcheck scripts/upgrade.sh` — zero warnings
- [ ] `.claude/scripts/validate.sh` — lint/type-check/build all pass

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)