### PR TITLE
docs(guides): add upgrading and troubleshooting guides

### DIFF
--- a/.claude/HANDOFF.md
+++ b/.claude/HANDOFF.md
@@ -1,39 +1,33 @@
-# Handoff — Issue #12: Create upgrade.sh with backup safety
+# Handoff — Issue #13: Write docs/UPGRADING.md and docs/TROUBLESHOOTING.md
 
 ## Goal
 
-Create `scripts/upgrade.sh` that safely upgrades the pinned Archon Docker image
-version with pre-upgrade SQLite backup and post-upgrade health validation.
+Create the final two documentation guides to complete the docs/ suite: UPGRADING.md for the version bump procedure and TROUBLESHOOTING.md as the central error resolution resource.
 
 ## What Was Done
 
-- **Created** `scripts/upgrade.sh` (212 lines, 12 functions):
-  - `stop_archon()` — mirrors sync-up.sh exactly; handles already-stopped gracefully
-  - `run_backup()` — calls backup.sh, captures stdout as backup path; **hard-fails** if DB missing (unlike sync-up.sh which tolerates missing DB — you can't upgrade what was never set up)
-  - `update_compose_tag()` / `revert_compose_tag()` — portable sed via mktemp/mv (no `sed -i`); update verifies with grep-q after write
-  - `pull_image()` — reverts compose file on pull failure (safe: no data touched before pull)
-  - `validate_health()` — delegates to health.sh, returns 1 without aborting
-  - `print_rollback_instructions()` — numbered 5-step guide with exact backup path and old tag embedded
-  - `main()` — full flow with `--dry-run`, idempotent same-version check, explicit exit codes (0/1/2)
+- **Created** `docs/UPGRADING.md` (260 lines): prerequisites, version pinning model, why backup is mandatory (no-migration constraint + WAL caveat), step-by-step upgrade procedure with `upgrade.sh` (all 6 phases with expected output), exit code 1 vs. exit code 2 scenarios, and 5-step manual rollback with ordering rationale.
+- **Created** `docs/TROUBLESHOOTING.md` (350 lines): 11 symptom-first sections (Docker not running, container won't start, API health failing, OAuth expired, database not found, upgrade exit code 2, sync remote not configured, sync other errors, permission denied, workflow missing, bind mount empty). Ends with "Still stuck?" contact section — no self-referencing "Something went wrong?" link.
+- **Updated** `docs/SETUP.md` line 247: replaced "coming soon — issue #13" placeholder with a proper markdown link to UPGRADING.md matching the format of surrounding list items.
 
 ## Key Decisions
 
-- **No auto-rollback on health failure** — the new Archon version may have modified DB schema during startup; auto-revert without DB restore would leave inconsistent state. Rollback instructions printed instead (exit code 2).
-- **Revert on pull failure only** — pull failure means no new image fetched and no data touched; safe to revert compose file. Contrast with health failure where data may already be modified.
-- **Hard backup failure** — unlike sync-up.sh which tolerates a missing DB for first-sync, upgrade.sh exits on backup failure. You cannot safely upgrade without a backup.
+- **TROUBLESHOOTING.md has a minimal prerequisites section** despite the PRP not listing one, because docs-guides.md mandates "What you need before starting" for every doc in docs/. The section is lightweight (repo cloned, terminal in repo root) so it orients without gatekeeping.
+- **Upgrade procedure phases shown without explicit "What you should see" labels** — all 6 phases are output from a single `./scripts/upgrade.sh` command, so the expected output is presented as sequential console output under each phase heading. Rollback steps (separate user commands) do use the explicit label.
+- **Existing inline troubleshooting left in place** in DAILY-USE.md (lines 260-280) and SHARING-WORKFLOWS.md (lines 124-137) per PRP CRITICAL guidance — TROUBLESHOOTING.md is the comprehensive reference, inline hints stay for contextual quick-fixes.
 
 ## Current State
 
-- `scripts/upgrade.sh` committed, PR created, issue #12 closed
-- Validation: 4 passed, 0 failed, 2 skipped
-- Shellcheck: 0 warnings
+- All files written, reviewed, validated (4 passed, 0 failed, 2 skipped)
+- All 5 existing docs' TROUBLESHOOTING.md dead links now resolve
+- SETUP.md UPGRADING.md link now resolves
+- docs/ suite is complete: SETUP → DAILY-USE → SHARING-WORKFLOWS → SYNC-BETWEEN-MACHINES → UPGRADING → TROUBLESHOOTING + WORKFLOW-OVERLAY
 
 ## Next Steps
 
-1. **Issue #13** — Create `docs/UPGRADING.md` and `docs/TROUBLESHOOTING.md`
-2. **Issue #19** — Define backup consistency model (cp vs sqlite3 .backup) — may affect upgrade.sh's pre-upgrade backup strategy
-3. **Issue #30** — Verify git-pull workflow sharing end-to-end
+1. **Issue #19** — Define backup consistency model (cp vs sqlite3 .backup)
+2. **Issue #30** — Verify git-pull workflow sharing end-to-end (CLI vs UI discrepancy referenced in TROUBLESHOOTING.md)
 
 ## Issue Tracker
 
-- #12: closed by PR
+- #13: closed by PR

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -244,7 +244,8 @@ Finally, open `http://localhost:3000` in your browser to access the Archon web U
   see [`docs/DAILY-USE.md`](DAILY-USE.md).
 - **Sync data across machines** — use `rclone` and the sync scripts; see
   [`docs/SYNC-BETWEEN-MACHINES.md`](SYNC-BETWEEN-MACHINES.md).
-- **Upgrade the pinned version** — see `docs/UPGRADING.md` (coming soon — issue #13).
+- **Upgrade the pinned version** — version bump procedure with backup safety; see
+  [`docs/UPGRADING.md`](UPGRADING.md).
 
 ## Something went wrong?
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,350 @@
+# Troubleshooting
+
+## What you need before starting
+
+- The archon-setup repository cloned on your machine
+- A terminal open in the repo root directory (`archon-setup/`)
+
+> Commands below assume you are in the repo root. Most fixes involve re-running a script
+> or restarting the container — no special tools beyond what SETUP.md already installed.
+
+Find the error message or behavior you see below, then follow the fix.
+
+> For upgrade failures specifically, see the rollback procedure in
+> [docs/UPGRADING.md](UPGRADING.md#rolling-back-manually).
+
+---
+
+## Docker not running
+
+**Symptom:** Any script or `docker compose` command fails with:
+
+```
+Cannot connect to the Docker daemon at unix:///var/run/docker.sock
+```
+
+**Cause:** Docker Desktop (macOS/Windows) is not running, or Docker Engine (Linux) is stopped.
+
+**Fix:**
+
+- **macOS / Windows:** Open Docker Desktop from your Applications folder (or Start menu). Wait
+  for the whale icon in the menu bar to stop animating before retrying.
+- **Linux:** Run `sudo systemctl start docker`
+
+Verify Docker is up:
+
+```bash
+docker info
+```
+
+This should return engine details without error.
+
+---
+
+## Container won't start
+
+**Symptom:** `docker compose up -d` exits with an error, or the container starts and immediately
+exits.
+
+**Diagnosis:** Check the container logs:
+
+```bash
+docker compose logs app
+```
+
+**Common causes:**
+
+**Port already in use:**
+
+```
+Error response from daemon: Ports are not available: ... address already in use
+```
+
+Another process is using port 3000. Change the port in `.env`:
+
+```
+PORT=3001
+```
+
+Then restart:
+
+```bash
+docker compose up -d
+```
+
+**Data directory owned by root:**
+
+```
+chown: changing ownership of '/.archon': Permission denied
+```
+
+Docker created `~/archon-data/` as root during a previous run (usually when a `docker compose`
+command was run with `sudo`). Fix the ownership:
+
+```bash
+sudo chown -R $USER ~/archon-data
+```
+
+Then restart:
+
+```bash
+docker compose up -d
+```
+
+---
+
+## API health check failing
+
+**Symptom:** `./scripts/health.sh` reports:
+
+```
+✗ Archon API: unreachable (http://localhost:3000/api/health)
+```
+
+**Cause:** Most of the time this is a timing issue. Archon's Docker healthcheck has a
+`start_period: 15s` — the container reports `starting` for the first 15 seconds regardless of
+actual readiness, and Archon itself needs a few additional seconds to initialize.
+
+**Fix:**
+
+1. Wait 20 seconds after starting, then re-run `./scripts/health.sh`.
+2. If still failing, check the logs: `docker compose logs app`
+3. If the logs show crash output, see "Container won't start" above.
+4. If PORT in `.env` differs from 3000, export it before running health.sh:
+   `PORT=3001 ./scripts/health.sh` (or set it in your shell environment).
+
+---
+
+## OAuth token expired
+
+**Symptom:** One or both of:
+
+- The workflow builder save stalls at approximately 89% and never completes
+- CLI operations fail with authentication errors
+
+**Cause:** The `CLAUDE_CODE_OAUTH_TOKEN` in `.env` has expired. The workflow YAML file is written
+to `.archon/workflows/` (you can see it in `git status`), but the SQLite record is not written, so
+the workflow does not appear in the Workflows Web UI page.
+
+**Fix:** Refresh the token — a browser window will open for you to sign in:
+
+```bash
+./scripts/setup-oauth.sh
+```
+
+Then restart Archon to pick up the new token from `.env`:
+
+```bash
+docker compose down && docker compose up -d
+```
+
+Do not manually paste a token value into `.env` — always use `setup-oauth.sh` to generate and
+write it safely.
+
+---
+
+## Database not found
+
+**Symptom:** `./scripts/backup.sh` (or any script that calls it) fails with:
+
+```
+✗ Database not found: /Users/you/archon-data/archon.db
+  Has Archon been started? Try: docker compose up -d
+```
+
+**Cause:** Archon creates `archon.db` on its first startup. If Archon has never run on this
+machine, the file does not exist yet.
+
+**Fix:** Start Archon and let it initialize:
+
+```bash
+docker compose up -d
+```
+
+Wait 20 seconds, then verify it is healthy:
+
+```bash
+./scripts/health.sh
+```
+
+Once healthy, re-run the backup script.
+
+---
+
+## Upgrade health check failed (exit code 2)
+
+**Symptom:** `./scripts/upgrade.sh` exits with code 2 and prints:
+
+```
+✗ Health check failed after upgrade. Manual rollback steps:
+  ...
+```
+
+**Cause:** The new Archon version started but its API did not pass the health check. The new
+version may have modified the SQLite database schema on startup, making a simple tag revert
+unsafe.
+
+**Fix:** Follow the 5-step rollback procedure in
+[docs/UPGRADING.md — Rolling back manually](UPGRADING.md#rolling-back-manually).
+
+The critical detail: **restore the database backup (step 2) before reverting the image tag
+(step 3)**. The new version may have already modified the schema — restoring the backup first
+ensures the old version sees data it understands.
+
+---
+
+## Sync failed — rclone remote not configured
+
+**Symptom:** `./scripts/sync-up.sh` or `./scripts/sync-down.sh` fails with:
+
+```
+✗ rclone remote 'gdrive:' is not configured. Run: rclone config
+```
+
+**Cause:** The rclone remote referenced in `RCLONE_REMOTE` (default: `gdrive:archon-data`) has
+not been configured on this machine.
+
+**Fix:** Run the rclone configuration wizard:
+
+```bash
+rclone config
+```
+
+Select "New remote", choose your provider type (e.g., `drive` for Google Drive), and complete the
+browser OAuth flow. See [docs/SYNC-BETWEEN-MACHINES.md](SYNC-BETWEEN-MACHINES.md) for full
+step-by-step rclone setup instructions.
+
+---
+
+## Sync failed — other rclone errors
+
+**Symptom:** The sync script starts, reaches the rclone transfer step, then fails with a transfer
+error (not the "remote not configured" message above).
+
+**Common causes:**
+
+- Network connectivity issues during the transfer
+- Expired cloud storage OAuth token (common with Google Drive after several months)
+- Remote storage quota exceeded
+
+**Diagnosis:** Test connectivity to the remote directly:
+
+```bash
+rclone lsd gdrive:
+```
+
+Replace `gdrive` with your remote name. If this command fails, the problem is with the remote
+connection, not with Archon.
+
+**Fix — re-authenticate the remote:**
+
+```bash
+rclone config reconnect gdrive:
+```
+
+Or run `rclone config` and select the existing remote to reconfigure it from scratch.
+
+---
+
+## Permission denied on ~/archon-data
+
+**Symptom:** The Archon container fails to start and `docker compose logs app` shows:
+
+```
+chown: changing ownership of '/.archon': Permission denied
+```
+
+**Cause:** `~/archon-data/` was created as root, usually because a `docker compose` command was
+run with `sudo` earlier. The container entrypoint runs `chown` over `/.archon` (the volume mount)
+and exits fatally if it lacks permission.
+
+**Fix:**
+
+```bash
+sudo chown -R $USER ~/archon-data
+```
+
+Then restart:
+
+```bash
+docker compose up -d
+```
+
+**What you should see:**
+
+```
+✔ Container archon-app  Started
+```
+
+---
+
+## Workflow not appearing after git pull
+
+**Symptom:** You pulled a workflow YAML file and restarted the container, but the workflow does
+not appear in the CLI or Web UI.
+
+**Checklist:**
+
+1. **Confirm the file exists on disk:**
+
+   ```bash
+   ls .archon/workflows/
+   ```
+
+2. **Restart the container after the pull** (a pull alone does not reload files):
+
+   ```bash
+   docker compose restart app
+   ```
+
+3. **Check the YAML has a `description:` field.** Open the file and verify the top-level keys
+   include `description:`. Archon's workflow discovery system skips files without this field.
+
+4. **CLI vs. Web UI discrepancy:** If the workflow appears in
+   `docker compose exec app archon workflow list` but not in the Workflows Web UI, this is a
+   known gap tracked in issue #30. The CLI reads YAML files directly; the UI reads the SQLite
+   database. A container restart normally reconciles these — if it does not, the `description:`
+   field is the most common culprit.
+
+---
+
+## Bind mount appears empty
+
+**Symptom:** Commands run inside the container do not see files from `.archon/workflows/` or
+`.archon/commands/`.
+
+**Cause:** The host directory may be empty, or files were added to the host after the container
+started without a restart. Archon resolves its config paths relative to its home directory
+(`/.archon`), which maps to `~/archon-data/` on the host — but the workflows and commands are
+separate bind mounts (`/.archon/.archon/workflows`), not subdirectories of that volume.
+
+**Fix:**
+
+1. Verify the host directory has files:
+
+   ```bash
+   ls .archon/workflows/
+   ```
+
+2. Restart the container to pick up any changes:
+
+   ```bash
+   docker compose restart app
+   ```
+
+3. Verify the files are visible inside the container:
+
+   ```bash
+   docker compose exec app ls /.archon/.archon/workflows/
+   ```
+
+---
+
+## Still stuck?
+
+Open an issue at [github.com/Thummpy/archon_core/issues](https://github.com/Thummpy/archon_core/issues)
+and include:
+
+- The exact command you ran
+- The full error output (copy-paste, not a screenshot)
+- Your OS and Docker version: `docker --version`

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,0 +1,260 @@
+# Upgrading Archon
+
+## What you need before starting
+
+- Completed [docs/SETUP.md](SETUP.md) — Archon running and healthy at least once
+- Docker Desktop (or Docker Engine) running on your machine
+- Repo up to date: run `git pull` from the repo root
+- The version tag you want to upgrade to — find available tags at:
+  - Upstream releases: `github.com/coleam00/archon/releases`
+  - GHCR package page: `github.com/coleam00/archon/pkgs/container/archon`
+
+> All commands in this guide run from the repo root directory (`archon-setup/`).
+
+## How version pinning works
+
+`docker-compose.yml` contains one line that determines which version of Archon runs:
+
+```yaml
+image: ghcr.io/coleam00/archon:0.3.6
+```
+
+This tag is the single source of truth. When you run `docker compose up -d`, Docker uses exactly
+that version — it never pulls a newer release automatically.
+
+To upgrade, you change the tag. `upgrade.sh` automates that process safely.
+
+Never set the tag to `latest`. A floating tag means any `docker compose pull` could silently
+change your Archon version, which may break your database schema or custom workflows without warning.
+
+## Why backup is mandatory
+
+**Archon has no database migration system.** When a new version of Archon starts for the first
+time, it may modify the SQLite schema to match what that version expects. If the upgrade fails or
+the new version is incompatible with your data, you cannot roll back without a backup — the schema
+change is already in the database.
+
+`upgrade.sh` always backs up `~/archon-data/archon.db` before changing anything. The backup is
+not optional and cannot be skipped.
+
+**Why the container must be stopped first:** SQLite uses a write-ahead log (WAL) — a staging area
+for recent writes that is only fully merged into the main database file when all connections close.
+
+`backup.sh` does not copy WAL sidecar files (`archon.db-wal`, `archon.db-shm`). Backing up while
+Archon is running may produce a copy missing recent writes. `upgrade.sh` stops the container
+before calling `backup.sh` specifically to prevent this.
+
+## Upgrade procedure
+
+### Preview the upgrade (dry run)
+
+Before upgrading, see exactly what the script will do without modifying anything:
+
+```bash
+./scripts/upgrade.sh 0.5.0 --dry-run
+```
+
+Replace `0.5.0` with your target tag.
+
+**What you should see:**
+
+```
+→ Upgrading Archon: 0.3.6 → 0.5.0
+  [dry-run] Would stop Archon (archon-app)
+  [dry-run] Would back up ~/archon-data/archon.db
+  [dry-run] Would update docker-compose.yml: 0.3.6 → 0.5.0
+  [dry-run] Would pull ghcr.io/coleam00/archon:0.5.0
+  [dry-run] Would restart Archon and validate health via scripts/health.sh
+```
+
+If this looks right, proceed with the actual upgrade.
+
+### Run the upgrade
+
+```bash
+./scripts/upgrade.sh 0.5.0
+```
+
+The script runs six phases in order:
+
+**Phase 1 — Stop Archon**
+
+```
+→ Stopping Archon (archon-app) via docker compose down...
+✓ Archon stopped
+```
+
+Archon is stopped so all SQLite connections close and the WAL checkpoint completes before backup.
+
+**Phase 2 — Backup the database**
+
+```
+→ Creating pre-upgrade backup...
+→ Ensuring backup directory exists: /path/to/archon-setup/backups
+→ Copying database to /path/to/archon-setup/backups/archon-20241201-143022.db...
+✓ Backup created: /path/to/archon-setup/backups/archon-20241201-143022.db
+✓ Pre-upgrade backup complete: /path/to/archon-setup/backups/archon-20241201-143022.db
+```
+
+Note the backup path printed here — you will need it if you have to roll back.
+
+**Phase 3 — Update the image tag**
+
+```
+→ Updating image tag in docker-compose.yml → 0.5.0
+✓ Image tag updated → 0.5.0
+```
+
+The `image:` line in `docker-compose.yml` is updated in place.
+
+**Phase 4 — Pull the new image**
+
+```
+→ Pulling new Archon image from GHCR...
+✓ Image pulled successfully
+```
+
+Docker downloads the new image from GitHub Container Registry. This step requires internet access
+and may take a minute depending on your connection.
+
+**Phase 5 — Start Archon**
+
+```
+→ Starting Archon...
+✓ Archon started
+```
+
+**Phase 6 — Validate health**
+
+```
+→ Validating health...
+→ Checking container status (archon-app)...
+✓ archon-app: running (healthy)
+→ Checking API health (http://localhost:3000/api/health)...
+✓ Archon API: OK
+
+✓ Upgrade complete: 0.3.6 → 0.5.0
+  Backup: /path/to/archon-setup/backups/archon-20241201-143022.db
+```
+
+The upgrade is done. Archon is running the new version with your data intact.
+
+## What happens if the upgrade fails
+
+`upgrade.sh` exits with a code that tells you exactly what state things are in.
+
+### Exit code 1 — Upgrade aborted, no damage
+
+The most common failure is a failed image pull (network error, nonexistent tag, GHCR outage).
+If the pull fails, `upgrade.sh` reverts `docker-compose.yml` to the original tag before exiting.
+Your database is untouched. Archon was already stopped — restart it on the original version:
+
+```bash
+docker compose up -d
+```
+
+**What you should see:**
+
+```
+✔ Container archon-app  Started
+```
+
+Verify health:
+
+```bash
+./scripts/health.sh
+```
+
+### Exit code 2 — Health check failed (dangerous)
+
+This is the critical failure case. The pull succeeded, Archon started with the new image, but the
+health check failed. The new version ran long enough to potentially modify the database schema
+before the health check expired. You cannot simply revert the image tag — the database may already
+be incompatible with the old version.
+
+Follow the manual rollback procedure below immediately.
+
+## Rolling back manually
+
+Use this procedure when `upgrade.sh` exits with code 2. The order is critical:
+**restore the backup before reverting the image tag.**
+
+**Step 1 — Stop Archon**
+
+```bash
+docker compose down
+```
+
+**What you should see:**
+
+```
+✔ Container archon-app  Stopped
+✔ Container archon-app  Removed
+```
+
+**Step 2 — Restore the database backup**
+
+Replace `<backup-path>` with the path printed during Phase 2 of the upgrade:
+
+```bash
+cp <backup-path> ~/archon-data/archon.db
+```
+
+Example:
+
+```bash
+cp backups/archon-20241201-143022.db ~/archon-data/archon.db
+```
+
+**Why this step comes first:** The new Archon version may have modified the database schema when
+it started up. If you revert the image tag first, the old version would start against a
+schema-modified database and fail. Restoring the backup first ensures the old version sees the
+data format it understands.
+
+**Step 3 — Revert the image tag in docker-compose.yml**
+
+Open `docker-compose.yml` and find the `image:` line:
+
+```yaml
+image: ghcr.io/coleam00/archon:0.5.0
+```
+
+Change it back to the previous version (the version before your upgrade attempt):
+
+```yaml
+image: ghcr.io/coleam00/archon:0.3.6
+```
+
+Save the file.
+
+**Step 4 — Restart Archon**
+
+```bash
+docker compose up -d
+```
+
+**What you should see:**
+
+```
+✔ Container archon-app  Started
+```
+
+**Step 5 — Verify health**
+
+```bash
+./scripts/health.sh
+```
+
+**What you should see:**
+
+```
+✓ archon-app: running (healthy)
+✓ Archon API: OK
+```
+
+Archon is restored to the previous version with your data intact. The failed new version's image
+remains cached locally but is no longer referenced — it will not run again until you upgrade again.
+
+## Something went wrong?
+
+See [docs/TROUBLESHOOTING.md](TROUBLESHOOTING.md) for common errors and fixes.


### PR DESCRIPTION
## Summary

- docs(guides): add upgrading and troubleshooting guides

**UPGRADING.md** (260 lines) — version pinning model, why backup is mandatory (no-migration constraint + WAL caveat), step-by-step `upgrade.sh` walkthrough with expected output at each phase, exit code 1 vs. exit code 2 scenarios, and 5-step manual rollback procedure.

**TROUBLESHOOTING.md** (350 lines) — 11 symptom-first entries covering Docker not running, container won't start, API health failing, OAuth expired, database not found, upgrade exit code 2, sync remote not configured, sync other rclone errors, permission denied, workflow missing after git pull, and bind mount appears empty. Ends with "Still stuck?" contact section.

**SETUP.md** — replaced "coming soon — issue #13" placeholder with a proper markdown link to UPGRADING.md.

All 5 existing docs' `TROUBLESHOOTING.md` dead links are now live. The docs/ suite is complete.

Closes #13

## Test plan

- [ ] Verify `docs/UPGRADING.md` renders correctly on GitHub (headers, code blocks, anchor links)
- [ ] Verify `docs/TROUBLESHOOTING.md` renders correctly on GitHub
- [ ] Verify SETUP.md "Next steps" link to UPGRADING.md resolves
- [ ] Verify cross-doc links to TROUBLESHOOTING.md from all 5 existing docs resolve
- [ ] Verify internal anchor link `UPGRADING.md#rolling-back-manually` from TROUBLESHOOTING.md resolves
- [ ] Confirm no "coming soon" text remains in SETUP.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)