### PR TITLE
feat(ops): replace cp with sqlite3 .backup for WAL-safe backups

### DIFF
--- a/.claude/HANDOFF.md
+++ b/.claude/HANDOFF.md
@@ -1,33 +1,31 @@
-# Handoff — Issue #13: Write docs/UPGRADING.md and docs/TROUBLESHOOTING.md
+# Handoff — Issue #19: Define Backup Consistency Model
 
 ## Goal
 
-Create the final two documentation guides to complete the docs/ suite: UPGRADING.md for the version bump procedure and TROUBLESHOOTING.md as the central error resolution resource.
+Replace `cp`-based backup in `scripts/backup.sh` with `sqlite3 .backup` (SQLite Online Backup API) to produce WAL-safe backups regardless of container state. Add ADR documenting the decision.
 
 ## What Was Done
 
-- **Created** `docs/UPGRADING.md` (260 lines): prerequisites, version pinning model, why backup is mandatory (no-migration constraint + WAL caveat), step-by-step upgrade procedure with `upgrade.sh` (all 6 phases with expected output), exit code 1 vs. exit code 2 scenarios, and 5-step manual rollback with ordering rationale.
-- **Created** `docs/TROUBLESHOOTING.md` (350 lines): 11 symptom-first sections (Docker not running, container won't start, API health failing, OAuth expired, database not found, upgrade exit code 2, sync remote not configured, sync other errors, permission denied, workflow missing, bind mount empty). Ends with "Still stuck?" contact section — no self-referencing "Something went wrong?" link.
-- **Updated** `docs/SETUP.md` line 247: replaced "coming soon — issue #13" placeholder with a proper markdown link to UPGRADING.md matching the format of surrounding list items.
+- **`scripts/backup.sh`** — replaced `cp -p` with `sqlite3 "${SOURCE_DB}" ".backup '${dest}'"` in `perform_backup()`; updated `check_deps()` to check for `sqlite3` with platform-specific install hints (macOS / Ubuntu/WSL); updated `usage()` to remove the old WAL WARNING and describe WAL-safe behavior.
+- **`.claude/docs/adr/0001-backup-consistency-model.md`** — new ADR documenting context (Archon hardcodes WAL mode), decision (sqlite3 Online Backup API), consequences (adds sqlite3 dep, removes live-backup risk), and three rejected alternatives.
+- **`.claude/examples/patterns/database-query.md`** — backup pattern updated to `sqlite3 .backup` with a WHY comment explaining WAL safety.
+- **`docs/UPGRADING.md`** — WAL paragraph rewritten: backup.sh now handles WAL internally; container still stopped for schema migration safety. Phase 1 and Phase 2 expected-output narration updated to match.
+- **`docs/TROUBLESHOOTING.md`** — new "sqlite3 not found" section added (symptom matches `check_deps()` output exactly; platform-specific fix instructions).
 
 ## Key Decisions
 
-- **TROUBLESHOOTING.md has a minimal prerequisites section** despite the PRP not listing one, because docs-guides.md mandates "What you need before starting" for every doc in docs/. The section is lightweight (repo cloned, terminal in repo root) so it orients without gatekeeping.
-- **Upgrade procedure phases shown without explicit "What you should see" labels** — all 6 phases are output from a single `./scripts/upgrade.sh` command, so the expected output is presented as sequential console output under each phase heading. Rollback steps (separate user commands) do use the explicit label.
-- **Existing inline troubleshooting left in place** in DAILY-USE.md (lines 260-280) and SHARING-WORKFLOWS.md (lines 124-137) per PRP CRITICAL guidance — TROUBLESHOOTING.md is the comprehensive reference, inline hints stay for contextual quick-fixes.
+- **sqlite3 .backup syntax** — uses single-quote wrapping: `".backup '${dest}'"`. The sqlite3 dot-command parser handles quoted filenames, making paths with spaces safe. The PRP explicitly specified this form.
+- **Container stop rationale in docs** — changed from "WAL checkpoint safety" to "schema migration safety" throughout UPGRADING.md. Both are true; the new backup mechanism removes the WAL dependency, leaving schema safety as the sole remaining reason.
+- **upgrade.sh and sync-up.sh unchanged** — callers continue to stop the container first for their own reasons and capture backup.sh's stdout path. No caller changes required.
 
 ## Current State
 
-- All files written, reviewed, validated (4 passed, 0 failed, 2 skipped)
-- All 5 existing docs' TROUBLESHOOTING.md dead links now resolve
-- SETUP.md UPGRADING.md link now resolves
-- docs/ suite is complete: SETUP → DAILY-USE → SHARING-WORKFLOWS → SYNC-BETWEEN-MACHINES → UPGRADING → TROUBLESHOOTING + WORKFLOW-OVERLAY
+Issue #19 complete. Validation passed (shellcheck, docker compose config). PR created; branch auto-deletes on merge.
 
 ## Next Steps
 
-1. **Issue #19** — Define backup consistency model (cp vs sqlite3 .backup)
-2. **Issue #30** — Verify git-pull workflow sharing end-to-end (CLI vs UI discrepancy referenced in TROUBLESHOOTING.md)
+1. **Issue #30** — Verify git-pull workflow sharing end-to-end (CLI vs UI discrepancy)
 
 ## Issue Tracker
 
-- #13: closed by PR
+- #19: closed via PR (auto-closes on merge via `Closes #19` in PR body)

--- a/.claude/docs/adr/0001-backup-consistency-model.md
+++ b/.claude/docs/adr/0001-backup-consistency-model.md
@@ -1,0 +1,68 @@
+# ADR-0001: Backup Consistency Model (sqlite3 .backup vs cp)
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-19
+
+## Context
+
+Archon's SQLite adapter unconditionally enables WAL mode at startup (`PRAGMA journal_mode = WAL`).
+This is hardcoded in upstream source and not configurable by operators.
+
+In WAL mode, recent writes are staged in a sidecar file (`archon.db-wal`) and are only merged into
+the main database file (`archon.db`) when all database connections close (a WAL checkpoint). A bare
+`cp` of `archon.db` while the container is running copies only the main file — it omits `archon.db-wal`
+and `archon.db-shm`. The resulting backup is missing any writes that have not yet been checkpointed,
+producing an inconsistent or incomplete snapshot. If the container is stopped before `cp` runs, the
+bun:sqlite connection pool closes, the WAL checkpoints automatically, and `cp` becomes safe — but
+this makes standalone `backup.sh` usage unsafe unless callers always stop the container first.
+
+The `scripts/backup.sh` script is called by:
+- `upgrade.sh` (which stops the container first for schema migration safety)
+- `sync-up.sh` (which stops the container first for sync consistency)
+- Users running it standalone (no container state guarantee)
+
+## Decision
+
+Replace `cp -p` in `scripts/backup.sh` with `sqlite3 "$SOURCE_DB" ".backup '$dest'"`.
+
+SQLite's Online Backup API (used by the `.backup` dot command) reads the database through the
+storage engine layer. It handles WAL checkpointing internally and produces a single, self-contained
+`.db` file that is consistent as of the moment the backup completes — regardless of whether the
+source database is being actively written to. No sidecar files are required to use the backup.
+
+The output filename and format are unchanged: a single timestamped `.db` file in `backups/`.
+
+## Consequences
+
+**Benefits:**
+- Standalone `backup.sh` usage is now safe against a running Archon instance.
+- The backup file is always complete — no risk of missing WAL-only writes.
+- Callers (`upgrade.sh`, `sync-up.sh`) are unaffected: they continue to stop the container first
+  for their own reasons, and their stdout contract (capturing the backup path) is preserved.
+
+**Trade-offs:**
+- `sqlite3` becomes an explicit runtime dependency. It ships pre-installed on macOS. On
+  Debian/Ubuntu and WSL it requires `sudo apt install sqlite3`. `check_deps()` in `backup.sh`
+  now checks for `sqlite3` and prints platform-specific install instructions if missing.
+
+**Constraints introduced:**
+- None beyond the new dependency.
+
+## Alternatives Considered
+
+**Keep `cp` with a prominent warning:** Rejected. A warning does not make the backup safe — it only
+shifts responsibility to the caller. Silent data loss (missing WAL writes) in a backup is worse than
+a dependency requirement.
+
+**Detect container state and conditionally use `cp` or `sqlite3 .backup`:** Rejected. This adds
+complexity (a `docker inspect` call, container name coupling) with no benefit — `sqlite3 .backup`
+is correct in all cases, including when the container is stopped.
+
+**Checkpoint WAL explicitly before `cp`:** Rejected. This requires an open database connection to
+issue `PRAGMA wal_checkpoint(FULL)`, which means `sqlite3` is required anyway. The `.backup` API
+is simpler and produces the same result.

--- a/.claude/examples/patterns/database-query.md
+++ b/.claude/examples/patterns/database-query.md
@@ -30,7 +30,8 @@ TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 DEST="backups/archon-${TIMESTAMP}.db"
 
 mkdir -p backups
-cp "${ARCHON_DATA}/archon.db" "${DEST}"
+# WAL-safe: Online Backup API checkpoints WAL internally; consistent against a running Archon instance
+sqlite3 "${ARCHON_DATA}/archon.db" ".backup '${DEST}'"
 echo "✓ Backup: ${DEST}"
 ```
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -171,6 +171,40 @@ Once healthy, re-run the backup script.
 
 ---
 
+## sqlite3 not found
+
+**Symptom:** `./scripts/backup.sh` (or any script that calls it) fails with:
+
+```
+✗ Required tool not found: sqlite3
+  macOS (pre-installed): brew install sqlite3
+  Ubuntu/WSL:            sudo apt install sqlite3
+```
+
+**Cause:** `backup.sh` uses `sqlite3`'s Online Backup API to create WAL-safe backups. `sqlite3`
+ships pre-installed on macOS but requires manual installation on Debian/Ubuntu and WSL.
+
+**Fix:**
+
+- **macOS:** `sqlite3` ships pre-installed. If missing, reinstall with:
+  ```bash
+  brew install sqlite3
+  ```
+- **Ubuntu / WSL:** Install with:
+  ```bash
+  sudo apt update && sudo apt install sqlite3
+  ```
+
+Verify the installation:
+
+```bash
+sqlite3 --version
+```
+
+Once installed, re-run the backup script.
+
+---
+
 ## Upgrade health check failed (exit code 2)
 
 **Symptom:** `./scripts/upgrade.sh` exits with code 2 and prints:

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -40,9 +40,11 @@ not optional and cannot be skipped.
 **Why the container must be stopped first:** SQLite uses a write-ahead log (WAL) — a staging area
 for recent writes that is only fully merged into the main database file when all connections close.
 
-`backup.sh` does not copy WAL sidecar files (`archon.db-wal`, `archon.db-shm`). Backing up while
-Archon is running may produce a copy missing recent writes. `upgrade.sh` stops the container
-before calling `backup.sh` specifically to prevent this.
+`backup.sh` uses `sqlite3`'s Online Backup API (`.backup` command), which handles WAL
+checkpointing internally and produces a consistent snapshot regardless of whether Archon is running.
+`upgrade.sh` still stops the container before backup, but for schema migration safety: a new
+Archon version may modify the database schema on first startup, and a clean stop ensures no partial
+write state persists before that migration runs.
 
 ## Upgrade procedure
 
@@ -84,14 +86,15 @@ The script runs six phases in order:
 ✓ Archon stopped
 ```
 
-Archon is stopped so all SQLite connections close and the WAL checkpoint completes before backup.
+Archon is stopped for schema migration safety — the new version may modify the database schema on
+first startup, and a clean stop ensures no partial write state before that migration runs.
 
 **Phase 2 — Backup the database**
 
 ```
 → Creating pre-upgrade backup...
 → Ensuring backup directory exists: /path/to/archon-setup/backups
-→ Copying database to /path/to/archon-setup/backups/archon-20241201-143022.db...
+→ Backing up database to /path/to/archon-setup/backups/archon-20241201-143022.db...
 ✓ Backup created: /path/to/archon-setup/backups/archon-20241201-143022.db
 ✓ Pre-upgrade backup complete: /path/to/archon-setup/backups/archon-20241201-143022.db
 ```

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -12,12 +12,13 @@ usage() {
   cat <<EOF
 Usage: $(basename "$0") [--help]
 
-Copies ~/archon-data/archon.db to backups/archon-YYYYMMDD-HHMMSS.db (UTC timestamp).
+Backs up ~/archon-data/archon.db to backups/archon-YYYYMMDD-HHMMSS.db (UTC timestamp).
 
-WARNING: For a consistent backup of a running Archon instance, stop the container
-first: docker compose down. This script does not stop the container and does not
-copy WAL/SHM sidecar files. Callers such as upgrade.sh and sync-up.sh already
-run docker compose down before invoking this script.
+Uses sqlite3's Online Backup API (.backup command), which handles WAL checkpointing
+internally. The backup is consistent even against a running Archon instance — no need
+to stop the container first. Callers such as upgrade.sh and sync-up.sh stop the
+container before calling this script for other reasons (schema migration safety,
+sync consistency), not for backup consistency.
 
 Stdout contract:
   On success, prints the absolute path of the created backup to stdout.
@@ -25,15 +26,19 @@ Stdout contract:
 
 Exit codes:
   0 — backup created successfully
-  1 — failure (DB missing, copy failed, required tool not found)
+  1 — failure (DB missing, backup failed, required tool not found)
 EOF
 }
 
 check_deps() {
   local missing=0
-  for cmd in cp mkdir date; do
+  for cmd in sqlite3 mkdir date; do
     if ! command -v "$cmd" &>/dev/null; then
       echo "✗ Required tool not found: ${cmd}" >&2
+      case "${cmd}" in
+        sqlite3) echo "  macOS (pre-installed): brew install sqlite3" >&2
+                 echo "  Ubuntu/WSL:            sudo apt install sqlite3" >&2 ;;
+      esac
       missing=1
     fi
   done
@@ -61,9 +66,9 @@ perform_backup() {
   timestamp=$(date -u +%Y%m%d-%H%M%S)
   local dest="${BACKUP_DIR}/${BACKUP_PREFIX}-${timestamp}.db"
 
-  echo "→ Copying database to ${dest}..." >&2
-  if ! cp -p "${SOURCE_DB}" "${dest}"; then
-    echo "✗ Backup failed (cp returned non-zero)" >&2
+  echo "→ Backing up database to ${dest}..." >&2
+  if ! sqlite3 "${SOURCE_DB}" ".backup '${dest}'"; then
+    echo "✗ Backup failed (sqlite3 returned non-zero)" >&2
     exit 1
   fi
 


### PR DESCRIPTION
## Summary

- Replace `cp -p` in `scripts/backup.sh` with `sqlite3 .backup` (SQLite Online Backup API), which handles WAL checkpointing internally and produces a consistent snapshot regardless of whether Archon is running
- Update `check_deps()` to check for `sqlite3` with platform-specific install instructions (macOS / Ubuntu/WSL)
- Add ADR `0001-backup-consistency-model.md` documenting the decision, alternatives considered, and consequences
- Update `docs/UPGRADING.md` WAL explanation to reflect new backup mechanism and correct the container-stop rationale (schema migration safety, not backup consistency)
- Add "sqlite3 not found" troubleshooting entry to `docs/TROUBLESHOOTING.md`
- Update `.claude/examples/patterns/database-query.md` backup pattern

Closes #19

## Test plan

- [x] `bash -n scripts/backup.sh` — syntax check passes
- [x] `shellcheck scripts/backup.sh` — passes clean
- [x] `.claude/scripts/validate.sh --skip-integration` — 4 passed, 0 failed, 2 skipped
- [x] `grep -q 'sqlite3.*\.backup' scripts/backup.sh` — confirmed
- [x] `grep -qv 'cp -p.*SOURCE_DB' scripts/backup.sh` — confirmed
- [x] ADR exists at `.claude/docs/adr/0001-backup-consistency-model.md` with Status: Accepted
- [x] TROUBLESHOOTING.md symptom block matches `check_deps()` stderr output exactly
- [ ] Manual integration test: run `scripts/backup.sh` against a live `~/archon-data/archon.db` and verify absolute path on stdout, consistent backup file

🤖 Generated with [Claude Code](https://claude.com/claude-code)