### PR TITLE
feat(ops): add workflow-sharing verification script and correct docs

### DIFF
--- a/.claude/HANDOFF.md
+++ b/.claude/HANDOFF.md
@@ -1,31 +1,48 @@
-# Handoff — Issue #19: Define Backup Consistency Model
+# Handoff — Issue #30: Verify git-pull workflow sharing
 
 ## Goal
 
-Replace `cp`-based backup in `scripts/backup.sh` with `sqlite3 .backup` (SQLite Online Backup API) to produce WAL-safe backups regardless of container state. Add ADR documenting the decision.
+Definitively test whether a hand-placed YAML file in `.archon/workflows/`
+(simulating `git pull` delivery) appears in Archon's Web UI or CLI after
+`docker compose restart app`. Correct all documentation based on findings.
 
 ## What Was Done
 
-- **`scripts/backup.sh`** — replaced `cp -p` with `sqlite3 "${SOURCE_DB}" ".backup '${dest}'"` in `perform_backup()`; updated `check_deps()` to check for `sqlite3` with platform-specific install hints (macOS / Ubuntu/WSL); updated `usage()` to remove the old WAL WARNING and describe WAL-safe behavior.
-- **`.claude/docs/adr/0001-backup-consistency-model.md`** — new ADR documenting context (Archon hardcodes WAL mode), decision (sqlite3 Online Backup API), consequences (adds sqlite3 dep, removes live-backup risk), and three rejected alternatives.
-- **`.claude/examples/patterns/database-query.md`** — backup pattern updated to `sqlite3 .backup` with a WHY comment explaining WAL safety.
-- **`docs/UPGRADING.md`** — WAL paragraph rewritten: backup.sh now handles WAL internally; container still stopped for schema migration safety. Phase 1 and Phase 2 expected-output narration updated to match.
-- **`docs/TROUBLESHOOTING.md`** — new "sqlite3 not found" section added (symptom matches `check_deps()` output exactly; platform-specific fix instructions).
+1. Created `scripts/verify-workflow-sharing.sh` — probes three channels:
+   API (`/api/workflows`), CLI (`archon workflow list`), and container
+   filesystem bind-mount. Includes health gating, EXIT trap cleanup, and
+   structured PASS/FAIL/UNAVAILABLE summary per channel.
+
+2. Ran the script against live Archon 0.3.6. Findings:
+   - **API: FAIL** — `/api/workflows` returns `{"workflows":[]}`. No startup
+     scan of `/.archon/.archon/workflows/`; UI reads SQLite exclusively.
+   - **CLI: UNAVAILABLE** — `archon` binary not in container PATH, exit 127.
+     All `docker compose exec app archon ...` commands fail the same way.
+   - **Bind-mount: PASS** — YAML file confirmed in container filesystem.
+
+3. Recorded Test 30 in `.claude/docs/smoke-tests.md` with verbatim output
+   and criterion-by-criterion analysis (append-only; Test 24 untouched).
+
+4. Corrected five documentation files:
+   - `docs/WORKFLOW-OVERLAY.md` — four "What you should see" sections updated
+   - `docs/SHARING-WORKFLOWS.md` — "issue #30/under investigation" refs replaced;
+     verification step changed to `docker compose exec app ls`
+   - `docs/DAILY-USE.md` — caveat added for unavailable `archon workflow list`;
+     "Workflow not found" troubleshooting item corrected
+   - `docs/TROUBLESHOOTING.md` — item 4 in workflow-not-appearing section updated
 
 ## Key Decisions
 
-- **sqlite3 .backup syntax** — uses single-quote wrapping: `".backup '${dest}'"`. The sqlite3 dot-command parser handles quoted filenames, making paths with spaces safe. The PRP explicitly specified this form.
-- **Container stop rationale in docs** — changed from "WAL checkpoint safety" to "schema migration safety" throughout UPGRADING.md. Both are true; the new backup mechanism removes the WAL dependency, leaving schema safety as the sole remaining reason.
-- **upgrade.sh and sync-up.sh unchanged** — callers continue to stop the container first for their own reasons and capture backup.sh's stdout path. No caller changes required.
-
-## Current State
-
-Issue #19 complete. Validation passed (shellcheck, docker compose config). PR created; branch auto-deletes on merge.
+- CLI classified UNAVAILABLE (not FAIL) — binary doesn't exist in PATH, which
+  is stronger than "command fails to list workflow".
+- "Workflow not found" troubleshooting in DAILY-USE.md was out of original PRP
+  scope but gave users broken advice (exit-127 error); fixed in review pass.
+- Follow-up issue #38 created for remaining `archon` CLI sections in DAILY-USE.md
+  (`archon workflow run/status/resume/doctor/isolation`) — need separate
+  investigation of whether an alternative invocation exists.
 
 ## Next Steps
 
-1. **Issue #30** — Verify git-pull workflow sharing end-to-end (CLI vs UI discrepancy)
-
-## Issue Tracker
-
-- #19: closed via PR (auto-closes on merge via `Closes #19` in PR body)
+- **Issue #38** — investigate `archon` CLI invocation in container and correct
+  remaining CLI sections in `docs/DAILY-USE.md`
+- **Issue #25** — OAuth token lifetime and refresh behavior (Test 25 pending)

--- a/.claude/docs/smoke-tests.md
+++ b/.claude/docs/smoke-tests.md
@@ -213,3 +213,104 @@ Criterion-by-criterion against issue #24 acceptance criteria:
 **Status: pending** (issue #25)
 
 Verifies the `CLAUDE_CODE_OAUTH_TOKEN` lifetime when used inside the Archon container, and whether Archon or the container provides any auto-refresh mechanism before expiry.
+
+---
+
+### Test 30 — git-pull workflow sharing (hand-placed YAML)
+
+**Status: FAIL** (verified 2026-05-19, issue #30)
+
+**What is tested:** Whether a YAML file hand-placed in `.archon/workflows/` (simulating a `git pull` delivery) appears in (a) the Workflows Web UI page via `GET /api/workflows` and (b) the Archon CLI via `archon workflow list` after `docker compose restart app`. This closes the gap left by Test 24, which only tested a save that stalled mid-way through the UI write-back — not a fully hand-placed file.
+
+**Commands executed:**
+
+```bash
+# Run the verification script (requires a running Archon container)
+scripts/verify-workflow-sharing.sh
+
+# Equivalent manual steps
+# 1. Create block-style test YAML
+cat > .archon/workflows/verify-sharing-test.yaml <<'YAML'
+name: verify-sharing-test
+description: Temporary verification workflow — created by verify-workflow-sharing.sh and removed on exit.
+provider: claude
+model: sonnet
+nodes:
+  - id: verify-node
+    prompt: |
+      Placeholder node for bind-mount discovery test.
+YAML
+
+# 2. Restart container
+docker compose restart app && sleep 20
+./scripts/health.sh
+
+# 3. API probe (UI data source)
+curl -sf http://localhost:3000/api/workflows
+
+# 4. CLI probe (separate stdout/stderr)
+docker compose exec -T app archon workflow list 2>&1
+
+# 5. Bind-mount sanity check
+docker compose exec -T app ls /.archon/.archon/workflows/verify-sharing-test.yaml
+
+# 6. Cleanup
+rm -f .archon/workflows/verify-sharing-test.yaml
+docker compose restart app && sleep 20
+./scripts/health.sh
+```
+
+**Verbatim output:**
+
+```
+→ Checking prerequisites...
+  ✓ docker, curl, jq available
+→ Gating on container health before testing...
+  ✓ archon-app running and API healthy
+→ Creating test YAML: /Users/chriscaldwell/Projects/archon_core/.archon/workflows/verify-sharing-test.yaml
+  ✓ Test YAML written (block-style, model: sonnet)
+→ Restarting container to simulate git-pull workflow discovery...
+ Container archon-app  Restarting
+ Container archon-app  Started
+→ Waiting for API health (post-restart)...
+  ✓ API healthy (5s)
+→ Check 1 — API probe: GET http://localhost:3000/api/workflows
+  Response: {"workflows":[]}
+  ✗ 'verify-sharing-test' not found in API response
+    UI Workflows page reads from SQLite — hand-placed YAML is not scanned at startup
+→ Check 2 — CLI probe: archon workflow list (inside container)
+  stdout: OCI runtime exec failed: exec failed: unable to start container process: exec: "archon": executable file not found in $PATH: unknown
+  exit code: 127
+  ✗ CLI command unavailable (exit 127 — binary not found in container PATH)
+→ Check 3 — Bind-mount: /.archon/.archon/workflows/verify-sharing-test.yaml in container
+  ✓ File confirmed in container filesystem
+
+══════════════════════════════════════════════════════════════════
+ verify-workflow-sharing.sh — Archon 0.3.6 result
+══════════════════════════════════════════════════════════════════
+ API (UI data source): FAIL
+ CLI:                  UNAVAILABLE
+ Bind-mount:           PASS
+══════════════════════════════════════════════════════════════════
+ Classification: FAIL — hand-placed YAML not visible via API or CLI
+
+ Record this output verbatim in .claude/docs/smoke-tests.md (Test 30).
+
+→ Cleanup: removing test YAML...
+→ Cleanup: restarting container to restore pre-test state...
+→ Waiting for API health (cleanup)...
+  ✓ API healthy (5s)
+✓ Cleanup complete.
+```
+
+**Classification: FAIL** (verified 2026-05-19, Archon 0.3.6)
+
+Criterion-by-criterion:
+
+1. **API probe — hand-placed YAML appears in `/api/workflows`** — **FAIL**. Response is `{"workflows":[]}`. Archon's startup log (see Test 24) confirms no scan of `/.archon/.archon/workflows/` at boot — only the bundled defaults path is verified. The UI reads exclusively from SQLite. A file delivered by `git pull` does not populate the SQLite layer, so it never appears in the Web UI.
+
+2. **CLI probe — `archon workflow list` discovers the workflow** — **UNAVAILABLE**. The `archon` binary is not in the container's PATH. `docker compose exec app archon workflow list` exits with code 127 (`exec: "archon": executable file not found in $PATH`). The health.sh `check_workflows` function wraps this call in `2>/dev/null` and reports "unknown" — this is consistent. The CLI commands documented in `docs/DAILY-USE.md` are not functional in Archon 0.3.6.
+
+3. **Bind-mount sanity — YAML file visible in container filesystem** — **PASS**. `/.archon/.archon/workflows/verify-sharing-test.yaml` confirmed present inside the container. Consistent with Test 23.
+
+**Key structural finding:** In Archon 0.3.6, `git pull + docker compose restart app` delivers workflow YAML to the container filesystem (bind-mount PASS) but the file is not discoverable through any available interface: the Web UI reads from SQLite (no startup scan of user workflows), and the `archon` CLI binary does not exist in the container PATH. The git-based team-sharing model works for file delivery only — not for UI or CLI discoverability in this version. Documentation corrections are applied in `docs/WORKFLOW-OVERLAY.md`, `docs/SHARING-WORKFLOWS.md`, and `docs/DAILY-USE.md`.

--- a/docs/DAILY-USE.md
+++ b/docs/DAILY-USE.md
@@ -118,6 +118,8 @@ docker compose exec app archon workflow list
 
 These are available even when `.archon/workflows/` is empty — they ship inside the Docker image. For details on how Archon resolves custom workflows alongside built-ins, see [docs/WORKFLOW-OVERLAY.md](WORKFLOW-OVERLAY.md).
 
+> **`archon workflow list` not available in Archon 0.3.6.** The `archon` binary is not in the container's PATH — the command exits with code 127 (confirmed in [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30). Use the Web UI at `http://localhost:3000/workflows` to browse workflows that have been saved through the builder.
+
 ## Running a workflow from the CLI
 
 ```bash
@@ -276,4 +278,10 @@ Wait 20 seconds and retry `./scripts/health.sh`. The healthcheck has a `start_pe
 
 ### Workflow not found
 
-Run `docker compose exec app archon workflow list` to confirm the name. Name matching is fuzzy (suffix and substring), but the workflow must exist on disk or in the SQLite database. If a custom workflow is missing, confirm the YAML file is in `.archon/workflows/` and the container was restarted after the file was added.
+In Archon 0.3.6, `docker compose exec app archon workflow list` is unavailable — the `archon` binary is not in the container PATH (confirmed in [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30). To check whether a workflow exists, use the Web UI at `http://localhost:3000/workflows` (for workflows with a SQLite record) or check the container filesystem directly:
+
+```bash
+docker compose exec app ls /.archon/.archon/workflows/
+```
+
+If a custom workflow is missing from that listing, confirm the YAML file is in `.archon/workflows/` on your host and the container was restarted after the file was added.

--- a/docs/SHARING-WORKFLOWS.md
+++ b/docs/SHARING-WORKFLOWS.md
@@ -18,9 +18,9 @@ After a teammate runs `git pull`, they restart the Archon container:
 docker compose restart app
 ```
 
-Archon reads `.archon/workflows/` through a bind mount — the directory on your machine is directly visible inside the container. After restart, any new YAML files are available to the Archon CLI. See [docs/WORKFLOW-OVERLAY.md](WORKFLOW-OVERLAY.md) for the full overlay resolution model.
+Archon reads `.archon/workflows/` through a bind mount — the directory on your machine is directly visible inside the container. After restart, new YAML files are present in the container filesystem. See [docs/WORKFLOW-OVERLAY.md](WORKFLOW-OVERLAY.md) for the full overlay resolution model.
 
-> **CLI vs. Web UI listing.** The Archon CLI (`archon workflow list`) discovers workflows from YAML files on disk. The Workflows page at `http://localhost:3000/workflows` reads from Archon's SQLite database — a YAML file placed on disk via `git pull` appears in the CLI but may not appear in the Web UI until it is opened and re-saved through the builder. This behavior is under investigation in issue #30.
+> **YAML files are not discoverable after `git pull` in Archon 0.3.6.** After `git pull + docker compose restart app`, the workflow YAML is delivered to the container filesystem (bind-mount confirmed) but is not listed by any available interface: the Web UI reads from SQLite and does not scan user YAML files at startup; the `archon` CLI binary is not in the container PATH (`archon workflow list` exits with code 127). Confirmed in [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30.
 
 ## Getting workflows from your team
 
@@ -48,15 +48,15 @@ docker compose restart app
 
 The restart takes about 5 seconds. Archon reads the updated overlay on startup.
 
-3. Confirm the workflow is available:
+3. Confirm the workflow was delivered to the container:
 
 ```bash
-docker compose exec app archon workflow list
+docker compose exec app ls /.archon/.archon/workflows/
 ```
 
-**What you should see:** The new workflow name appears in the list.
+**What you should see:** The new workflow YAML filename appears in the directory listing. This confirms the bind-mount delivered the file.
 
-> **Workflow appears in CLI but not in the Workflows Web UI page?** This is expected — the UI reads from SQLite, not YAML files. The CLI is the reliable way to confirm a git-pulled workflow is loaded. See [Something went wrong?](#something-went-wrong) for more detail.
+> **The Web UI and CLI will not list the workflow in Archon 0.3.6.** The Workflows page reads from SQLite (not YAML files), and the `archon` CLI binary is not in the container PATH — `archon workflow list` exits with code 127. Container filesystem listing is the only way to verify delivery. Confirmed in [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30.
 
 ## Contributing a workflow
 
@@ -71,7 +71,7 @@ git commit -m "feat(workflow): add <name> workflow"
 git push
 ```
 
-**What you should see:** The push succeeds. Teammates who run `git pull` followed by `docker compose restart app` will have the workflow available in their CLI.
+**What you should see:** The push succeeds. Teammates who run `git pull` followed by `docker compose restart app` will have the YAML file delivered to the container filesystem. In Archon 0.3.6, the workflow is not discoverable via the Web UI or CLI — see [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30 for the confirmed finding.
 
 > **`description:` is required on every workflow YAML.** Archon's skill discovery system uses this field. A workflow without `description:` may not appear in tool lists or the Web UI.
 
@@ -123,9 +123,9 @@ See [docs/TROUBLESHOOTING.md](TROUBLESHOOTING.md) for common errors and fixes.
 
 ### Workflow not appearing after git pull + restart
 
-If the workflow appears in `docker compose exec app archon workflow list` but not in the Workflows Web UI, this is expected — the UI reads from SQLite while the CLI reads YAML files. Issue #30 is tracking the gap.
+In Archon 0.3.6, a workflow YAML delivered by `git pull` will not appear in the Web UI (reads from SQLite) or via `archon workflow list` (binary not in container PATH). This is confirmed behavior — see [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30. Container filesystem listing (`docker compose exec app ls /.archon/.archon/workflows/`) is the only way to verify the file was delivered.
 
-If the workflow does not appear in the CLI either, check:
+If the YAML file is not present in the container filesystem at all, check:
 
 1. The YAML file exists on disk: `ls .archon/workflows/`
 2. The container was restarted after the pull: `docker compose restart app`

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -334,11 +334,16 @@ not appear in the CLI or Web UI.
 3. **Check the YAML has a `description:` field.** Open the file and verify the top-level keys
    include `description:`. Archon's workflow discovery system skips files without this field.
 
-4. **CLI vs. Web UI discrepancy:** If the workflow appears in
-   `docker compose exec app archon workflow list` but not in the Workflows Web UI, this is a
-   known gap tracked in issue #30. The CLI reads YAML files directly; the UI reads the SQLite
-   database. A container restart normally reconciles these — if it does not, the `description:`
-   field is the most common culprit.
+4. **CLI and Web UI do not list git-pulled workflows in Archon 0.3.6.** This is confirmed behavior
+   (see [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30). The Web UI reads from
+   SQLite and does not scan YAML files at startup. The `archon` binary is not in the container PATH —
+   `archon workflow list` exits with code 127. Verify delivery with:
+
+   ```bash
+   docker compose exec app ls /.archon/.archon/workflows/
+   ```
+
+   The file being present in that listing confirms the bind-mount delivered it correctly.
 
 ---
 

--- a/docs/WORKFLOW-OVERLAY.md
+++ b/docs/WORKFLOW-OVERLAY.md
@@ -83,7 +83,7 @@ touch .archon/workflows/my-workflow.yaml
 docker compose restart app
 ```
 
-**What you should see:** The workflow appears in the Archon UI and CLI within ~5 seconds of restart.
+**What you should see:** The YAML file is present in the container filesystem (bind-mount confirmed). However, in Archon 0.3.6 the workflow **does not appear in the Web UI** — the Workflows page reads from SQLite and Archon does not scan `/.archon/.archon/workflows/` at startup. The `archon` CLI binary is not in the container PATH in this version, so `archon workflow list` is unavailable. Confirmed in [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30.
 
 ### 3. Claude Code with the Archon skill
 
@@ -110,7 +110,7 @@ Then restart the container:
 docker compose restart app
 ```
 
-**What you should see:** The bundled default no longer appears or executes; your override file takes its place in the UI and CLI.
+**What you should see:** The override file is present in the container filesystem and takes priority for workflow execution (the bundled default is shadowed). The override does not appear in the Web UI — the Workflows page reads from SQLite, not from YAML files on disk. Confirmed in [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30.
 
 ## How to restore a default
 
@@ -124,7 +124,7 @@ docker compose restart app
 
 `git rm` stages the deletion and removes the file from disk. After the commit, teammates who run `git pull` followed by `docker compose restart app` will also see the default restored.
 
-**What you should see:** The bundled default reappears in the Archon UI and CLI after restart.
+**What you should see:** The override file is removed from the container filesystem and the bundled default is no longer suppressed for execution. The Web UI is unaffected by this change — it reads from SQLite, not from YAML files on disk.
 
 ## Git workflow after building in the UI
 
@@ -159,7 +159,7 @@ git commit -m "feat(workflow): add <name> workflow"
 git push
 ```
 
-**What you should see:** The push succeeds and teammates can `git pull` to receive the workflow, then `docker compose restart app` to load it.
+**What you should see:** The push succeeds and teammates can `git pull` to receive the YAML file. After `docker compose restart app`, the workflow is in the container filesystem. In Archon 0.3.6, it will not appear in the Web UI (reads from SQLite) and the `archon` CLI is unavailable — see [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30. Verify delivery with `docker compose exec app ls /.archon/.archon/workflows/`.
 
 > **`description:` is required on every workflow YAML.** Archon's skill discovery system and the vscode-archon extension use this field to list available workflows. A workflow without `description:` may not appear in tool lists or the extension's UI.
 

--- a/scripts/verify-workflow-sharing.sh
+++ b/scripts/verify-workflow-sharing.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+readonly TEST_WORKFLOW_NAME="verify-sharing-test"
+readonly TEST_WORKFLOW_PATH="${PROJECT_DIR}/.archon/workflows/${TEST_WORKFLOW_NAME}.yaml"
+readonly DEFAULT_PORT=3000
+readonly HEALTH_TIMEOUT=90
+readonly HEALTH_INTERVAL=5
+
+# Written by each probe function; read by print_summary.
+API_RESULT="not run"
+CLI_RESULT="not run"
+MOUNT_RESULT="not run"
+
+cleanup() {
+  echo ""
+  echo "→ Cleanup: removing test YAML..."
+  rm -f "${TEST_WORKFLOW_PATH}"
+  if docker info &>/dev/null; then
+    echo "→ Cleanup: restarting container to restore pre-test state..."
+    docker compose -f "${PROJECT_DIR}/docker-compose.yml" restart app 2>/dev/null || true
+    wait_for_health "cleanup" || true
+  fi
+  echo "✓ Cleanup complete."
+}
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--help]
+
+Tests whether a hand-placed YAML file in .archon/workflows/ appears in
+Archon's Web UI (/api/workflows) and CLI (archon workflow list) after
+docker compose restart app. Verifies the git-pull team-sharing model.
+
+Checks performed:
+  1. API probe     — GET /api/workflows, search for test workflow name
+  2. CLI probe     — archon workflow list inside container, stdout+stderr captured
+  3. Bind-mount    — confirm file visible inside container at expected path
+
+Exit codes:
+  0 — test ran to completion (PASS/FAIL/PARTIAL reported, not an exit code)
+  1 — infrastructure failure (container not running, health timeout)
+
+Environment variables:
+  PORT  Host port Archon is bound to (default: ${DEFAULT_PORT})
+EOF
+}
+
+check_deps() {
+  echo "→ Checking prerequisites..."
+  local missing=0
+  for cmd in docker curl; do
+    if ! command -v "$cmd" &>/dev/null; then
+      echo "  ✗ Required tool not found: $cmd"
+      case "$cmd" in
+        docker) echo "    Install: https://docs.docker.com/get-docker/" ;;
+        curl)   echo "    Install: brew install curl (macOS) | apt-get install curl (Linux)" ;;
+      esac
+      missing=1
+    fi
+  done
+  if [ "$missing" -ne 0 ]; then
+    exit 1
+  fi
+  if command -v jq &>/dev/null; then
+    echo "  ✓ docker, curl, jq available"
+  else
+    echo "  ✓ docker, curl available (jq not found — raw JSON output)"
+  fi
+}
+
+gate_container_healthy() {
+  echo "→ Gating on container health before testing..."
+  local port="${PORT:-${DEFAULT_PORT}}"
+  local ps_output container_line state
+
+  ps_output=$(docker compose -f "${PROJECT_DIR}/docker-compose.yml" ps --format json 2>/dev/null) || ps_output=""
+  container_line=$(echo "$ps_output" | grep '"Name":"archon-app"' 2>/dev/null) || container_line=""
+
+  if [ -z "$container_line" ]; then
+    echo "  ✗ archon-app: not found (not running)"
+    echo "    Start it first: docker compose up -d"
+    exit 1
+  fi
+
+  state=$(echo "$container_line" | grep -o '"State":"[^"]*"' | cut -d'"' -f4) || state=""
+
+  if [ "${state}" != "running" ]; then
+    echo "  ✗ archon-app: not running (state: ${state:-unknown})"
+    echo "    Start it first: docker compose up -d"
+    exit 1
+  fi
+
+  if ! curl -sf --max-time 5 "http://localhost:${port}/api/health" &>/dev/null; then
+    echo "  ✗ API health check failed — container running but API not ready"
+    echo "    Wait 20s and retry, or check logs: docker compose logs app"
+    exit 1
+  fi
+
+  echo "  ✓ archon-app running and API healthy"
+}
+
+wait_for_health() {
+  local label="${1:-}"
+  local port="${PORT:-${DEFAULT_PORT}}"
+  local url="http://localhost:${port}/api/health"
+  local elapsed=0
+
+  echo "→ Waiting for API health${label:+ (${label})}..."
+  while [ "$elapsed" -lt "$HEALTH_TIMEOUT" ]; do
+    if curl -sf --max-time 5 "$url" &>/dev/null; then
+      echo "  ✓ API healthy (${elapsed}s)"
+      return 0
+    fi
+    sleep "${HEALTH_INTERVAL}"
+    elapsed=$((elapsed + HEALTH_INTERVAL))
+  done
+
+  echo "  ✗ API did not become healthy within ${HEALTH_TIMEOUT}s"
+  return 1
+}
+
+create_test_workflow() {
+  echo "→ Creating test YAML: ${TEST_WORKFLOW_PATH}"
+  rm -f "${TEST_WORKFLOW_PATH}"
+  cat > "${TEST_WORKFLOW_PATH}" <<'YAML'
+name: verify-sharing-test
+description: Temporary verification workflow — created by verify-workflow-sharing.sh and removed on exit.
+provider: claude
+model: sonnet
+nodes:
+  - id: verify-node
+    prompt: |
+      This is a placeholder node. This workflow exists only to test whether
+      hand-placed YAML files are discovered by Archon after a container restart.
+      It is not intended to be run and will be removed automatically on script exit.
+YAML
+  echo "  ✓ Test YAML written (block-style, model: sonnet)"
+}
+
+probe_api() {
+  local port="${PORT:-${DEFAULT_PORT}}"
+  local url="http://localhost:${port}/api/workflows"
+  echo "→ Check 1 — API probe: GET ${url}"
+
+  local response
+  if ! response=$(curl -sf --max-time 10 "$url" 2>/dev/null); then
+    API_RESULT="FAIL (curl error)"
+    echo "  ✗ curl returned non-zero — API unreachable"
+    return
+  fi
+
+  if command -v jq &>/dev/null; then
+    echo "  Response: $(echo "$response" | jq -c '.')"
+  else
+    echo "  Response: ${response}"
+  fi
+
+  if echo "$response" | grep -q "${TEST_WORKFLOW_NAME}"; then
+    API_RESULT="PASS"
+    echo "  ✓ '${TEST_WORKFLOW_NAME}' found in API response"
+  else
+    API_RESULT="FAIL"
+    echo "  ✗ '${TEST_WORKFLOW_NAME}' not found in API response"
+    echo "    UI Workflows page reads from SQLite — hand-placed YAML is not scanned at startup"
+  fi
+}
+
+probe_cli() {
+  echo "→ Check 2 — CLI probe: archon workflow list (inside container)"
+  local tmp_stderr cli_stdout="" cli_exit=0
+  tmp_stderr=$(mktemp)
+
+  cli_stdout=$(docker compose -f "${PROJECT_DIR}/docker-compose.yml" exec -T app \
+    archon workflow list 2>"$tmp_stderr") || cli_exit=$?
+  local cli_stderr
+  cli_stderr=$(cat "$tmp_stderr" 2>/dev/null || true)
+  rm -f "$tmp_stderr"
+
+  echo "  stdout: ${cli_stdout:-(empty)}"
+  if [ -n "$cli_stderr" ]; then
+    echo "  stderr: ${cli_stderr}"
+  fi
+  if [ "$cli_exit" -ne 0 ]; then
+    echo "  exit code: ${cli_exit}"
+  fi
+
+  # Exit code 127 = command not found (POSIX standard for exec failures)
+  if [ "$cli_exit" -eq 127 ]; then
+    CLI_RESULT="UNAVAILABLE"
+    echo "  ✗ CLI command unavailable (exit 127 — binary not found in container PATH)"
+    return
+  fi
+
+  if echo "${cli_stdout}${cli_stderr}" | grep -qiE \
+    "command not found|unknown command|is not a.*command|executable file not found|OCI runtime exec failed"; then
+    CLI_RESULT="UNAVAILABLE"
+    echo "  ✗ CLI command unavailable (not found / exec failed)"
+    return
+  fi
+
+  if [ "$cli_exit" -ne 0 ] && [ -z "$cli_stdout" ]; then
+    CLI_RESULT="UNAVAILABLE"
+    echo "  ✗ CLI command exited ${cli_exit} with no output — may not be supported in this version"
+    return
+  fi
+
+  if echo "$cli_stdout" | grep -q "${TEST_WORKFLOW_NAME}"; then
+    CLI_RESULT="PASS"
+    echo "  ✓ '${TEST_WORKFLOW_NAME}' found in CLI output"
+  else
+    CLI_RESULT="FAIL"
+    echo "  ✗ '${TEST_WORKFLOW_NAME}' not found in CLI output"
+  fi
+}
+
+probe_mount() {
+  local container_path="/.archon/.archon/workflows/${TEST_WORKFLOW_NAME}.yaml"
+  echo "→ Check 3 — Bind-mount: ${container_path} in container"
+
+  if docker compose -f "${PROJECT_DIR}/docker-compose.yml" exec -T app \
+    ls "$container_path" &>/dev/null 2>&1; then
+    MOUNT_RESULT="PASS"
+    echo "  ✓ File confirmed in container filesystem"
+  else
+    MOUNT_RESULT="FAIL"
+    echo "  ✗ File not found in container — bind-mount not working?"
+  fi
+}
+
+print_summary() {
+  echo ""
+  echo "══════════════════════════════════════════════════════════════════"
+  echo " verify-workflow-sharing.sh — Archon 0.3.6 result"
+  echo "══════════════════════════════════════════════════════════════════"
+  echo " API (UI data source): ${API_RESULT}"
+  echo " CLI:                  ${CLI_RESULT}"
+  echo " Bind-mount:           ${MOUNT_RESULT}"
+  echo "══════════════════════════════════════════════════════════════════"
+
+  if [ "${API_RESULT}" = "PASS" ] && [ "${CLI_RESULT}" = "PASS" ]; then
+    echo " Classification: PASS — workflow visible in both UI (API) and CLI"
+  elif [ "${API_RESULT}" = "PASS" ] || [ "${CLI_RESULT}" = "PASS" ]; then
+    echo " Classification: PARTIAL — one channel sees the workflow, other does not"
+  else
+    echo " Classification: FAIL — hand-placed YAML not visible via API or CLI"
+  fi
+
+  echo ""
+  echo " Record this output verbatim in .claude/docs/smoke-tests.md (Test 30)."
+}
+
+main() {
+  if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    usage
+    exit 0
+  fi
+
+  trap cleanup EXIT
+
+  check_deps
+  gate_container_healthy
+  create_test_workflow
+
+  echo "→ Restarting container to simulate git-pull workflow discovery..."
+  docker compose -f "${PROJECT_DIR}/docker-compose.yml" restart app
+  wait_for_health "post-restart" || {
+    echo "✗ Container did not become healthy after restart — aborting test"
+    exit 1
+  }
+
+  probe_api
+  probe_cli
+  probe_mount
+  print_summary
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds `scripts/verify-workflow-sharing.sh` to definitively test whether a git-pulled YAML workflow file is discoverable in Archon's Web UI and CLI after `docker compose restart app`
- Ran live verification against Archon 0.3.6: **API: FAIL** (UI reads SQLite, no startup scan), **CLI: UNAVAILABLE** (`archon` binary not in container PATH, exit 127), **Bind-mount: PASS**
- Corrects inaccurate claims across five documentation files (`WORKFLOW-OVERLAY.md`, `SHARING-WORKFLOWS.md`, `DAILY-USE.md`, `TROUBLESHOOTING.md`, `.claude/docs/smoke-tests.md`) that stated hand-placed YAML appears in the UI or CLI after restart
- Replaces broken `archon workflow list` verification steps with `docker compose exec app ls /.archon/.archon/workflows/`
- Creates follow-up issue #38 for remaining `archon` CLI sections in `DAILY-USE.md` (out of scope for this PR)

## Test plan

- [x] `scripts/verify-workflow-sharing.sh` passes `shellcheck`
- [x] Script ran live against Archon 0.3.6 — verbatim output recorded in `.claude/docs/smoke-tests.md` Test 30
- [x] `.claude/scripts/validate.sh` passes (lint, docker compose config, build)
- [x] No "under investigation in issue #30" language remains in `docs/`
- [x] Test YAML (`verify-sharing-test.yaml`) is not committed — created and removed at runtime by the script

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)