### PR TITLE
docs: update 0.3.12 verified YAML discovery behavior and built-in list

### DIFF
--- a/.claude/docs/smoke-tests.md
+++ b/.claude/docs/smoke-tests.md
@@ -314,3 +314,98 @@ Criterion-by-criterion:
 3. **Bind-mount sanity — YAML file visible in container filesystem** — **PASS**. `/.archon/.archon/workflows/verify-sharing-test.yaml` confirmed present inside the container. Consistent with Test 23.
 
 **Key structural finding:** In Archon 0.3.6, `git pull + docker compose restart app` delivers workflow YAML to the container filesystem (bind-mount PASS) but the file is not discoverable through any available interface: the Web UI reads from SQLite (no startup scan of user workflows), and the `archon` CLI binary does not exist in the container PATH. The git-based team-sharing model works for file delivery only — not for UI or CLI discoverability in this version. Documentation corrections are applied in `docs/WORKFLOW-OVERLAY.md`, `docs/SHARING-WORKFLOWS.md`, and `docs/DAILY-USE.md`.
+
+---
+
+## Verification log — Archon 0.3.12 (verified 2026-05-20)
+
+### Test 30 (re-run) — git-pull workflow sharing (hand-placed YAML)
+
+**Status: PASS** (re-verified 2026-05-20, issue #40 follow-up)
+
+**What changed from 0.3.6:** Upstream PR #1315 unified workflow discovery directly under `getArchonHome()` (`/.archon`). Mount paths changed from `/.archon/.archon/workflows` to `/.archon/workflows`. Discovery behavior also changed — YAML files are scanned at startup.
+
+**Commands executed:**
+
+```bash
+# Write test YAML to host (no SQLite record written)
+cat > .archon/workflows/verify-sharing-test.yaml << 'YAML'
+name: verify-sharing-test
+description: Temporary verification workflow — created manually and removed on exit.
+provider: claude
+model: sonnet
+nodes:
+  - id: verify-node
+    prompt: |
+      This is a placeholder node for path verification only.
+YAML
+
+# Restart container
+docker compose restart app
+until curl -sf --max-time 5 http://localhost:3000/api/health &>/dev/null; do sleep 3; done
+
+# API probe (UI data source)
+curl -sf http://localhost:3000/api/workflows | grep -o '"name":"verify-sharing-test"'
+
+# Bind-mount sanity check
+docker compose exec app ls -la /.archon/workflows/verify-sharing-test.yaml
+
+# CLI probe
+docker compose exec app archon workflow list 2>&1; echo "exit: $?"
+
+# Full workflow name list
+curl -sf http://localhost:3000/api/workflows | grep -o '"name":"[^"]*"' | sort
+
+# Cleanup
+rm -f .archon/workflows/verify-sharing-test.yaml
+docker compose restart app
+```
+
+**Verbatim output:**
+
+```
+# API probe
+"name":"verify-sharing-test"
+
+# Bind-mount
+/.archon/workflows/verify-sharing-test.yaml  (file present, owned by appuser)
+
+# CLI probe
+OCI runtime exec failed: exec failed: unable to start container process: exec: "archon": executable file not found in $PATH: unknown
+exit: 127
+
+# Full workflow name list (20 entries)
+"name":"archon-adversarial-dev"
+"name":"archon-architect"
+"name":"archon-assist"
+"name":"archon-comprehensive-pr-review"
+"name":"archon-create-issue"
+"name":"archon-feature-development"
+"name":"archon-fix-github-issue"
+"name":"archon-idea-to-pr"
+"name":"archon-interactive-prd"
+"name":"archon-issue-review-full"
+"name":"archon-piv-loop"
+"name":"archon-plan-to-pr"
+"name":"archon-ralph-dag"
+"name":"archon-refactor-safely"
+"name":"archon-remotion-generate"
+"name":"archon-resolve-conflicts"
+"name":"archon-smart-pr-review"
+"name":"archon-test-loop-dag"
+"name":"archon-validate-pr"
+"name":"archon-workflow-builder"
+"name":"verify-sharing-test"
+```
+
+**Classification: PASS**
+
+Criterion-by-criterion:
+
+1. **API probe — hand-placed YAML appears in `/api/workflows`** — **PASS**. `verify-sharing-test` present in API response. Archon 0.3.12 discovers YAML files in `/.archon/workflows/` at startup — no SQLite record required.
+
+2. **CLI probe — `archon workflow list` discovers the workflow** — **UNAVAILABLE**. The `archon` binary is still not in the container's PATH in 0.3.12. Exit code 127 — unchanged from 0.3.6. This is confirmed permanent upstream design (Dockerfile does not add the binary to PATH).
+
+3. **Bind-mount sanity — YAML file visible in container filesystem** — **PASS**. `/.archon/workflows/verify-sharing-test.yaml` confirmed present. New path (no doubled prefix) consistent with upstream PR #1315.
+
+**Key structural finding:** In Archon 0.3.12, `git pull + docker compose restart app` delivers workflow YAML to the container filesystem AND makes it discoverable via the Web UI (`GET /api/workflows`). The git-based team-sharing model is fully functional for Web UI discoverability. CLI unavailability is unchanged — permanent upstream design decision. Documentation updated in `docs/WORKFLOW-OVERLAY.md`, `docs/SHARING-WORKFLOWS.md`, `docs/DAILY-USE.md`, and `docs/TROUBLESHOOTING.md`.

--- a/docs/DAILY-USE.md
+++ b/docs/DAILY-USE.md
@@ -93,32 +93,36 @@ Errors appear as `[ERROR]` lines. If Archon fails to start, the container logs a
 
 ## Listing available workflows
 
-List every workflow available — Archon's 10 built-ins plus any custom workflows in `.archon/workflows/`:
+Browse available workflows in the Web UI at `http://localhost:3000/workflows`. In 0.3.12, this page shows both built-in workflows and any custom YAML files in `.archon/workflows/` — no CLI required.
 
-```bash
-docker compose exec app archon workflow list
-```
+> **`archon workflow list` not available.** The `archon` binary is not in the container's PATH by design — the upstream Dockerfile does not add it, so the command exits with code 127.
 
-`docker compose exec app` sends the command into the running container. Archon runs inside Docker, so all Archon CLI commands use this prefix.
+Archon's built-in workflows in 0.3.12 (verified 2026-05-20):
 
-**What you should see:** A table of workflow names and descriptions. Archon's built-in workflows:
-
-| Workflow | Description |
+| Workflow | Trigger / purpose |
 |---|---|
-| `archon-assist` | Answer questions about the codebase |
-| `archon-fix-github-issue` | Investigate and fix a GitHub issue |
-| `archon-idea-to-pr` | Turn a plain-language idea into a pull request |
-| `archon-plan-to-pr` | Turn a structured plan into a pull request |
-| `archon-feature-development` | End-to-end feature development |
-| `archon-smart-pr-review` | Focused, targeted PR review |
-| `archon-comprehensive-pr-review` | In-depth PR review with full context |
-| `archon-architect` | Architectural analysis and design recommendations |
-| `archon-ralph-dag` | Build a directed-acyclic graph of tasks |
-| `archon-resolve-conflicts` | Resolve git merge conflicts |
+| `archon-adversarial-dev` | Build a complete application from scratch using adversarial development |
+| `archon-architect` | Architectural sweep, complexity reduction, or system design |
+| `archon-assist` | General-purpose — use when no other workflow matches |
+| `archon-comprehensive-pr-review` | Comprehensive code review of a pull request |
+| `archon-create-issue` | Report a bug or problem as a GitHub issue |
+| `archon-feature-development` | Implement a feature from an existing plan |
+| `archon-fix-github-issue` | Fix, resolve, or implement a solution for a GitHub issue |
+| `archon-idea-to-pr` | Feature idea or description → end-to-end pull request |
+| `archon-interactive-prd` | Create a PRD through guided conversation |
+| `archon-issue-review-full` | Full fix + review pipeline for a GitHub issue |
+| `archon-piv-loop` | Guided Plan-Implement-Validate development loop |
+| `archon-plan-to-pr` | Existing implementation plan → execute as pull request |
+| `archon-ralph-dag` | Ralph implementation loop (directed acyclic graph) |
+| `archon-refactor-safely` | Refactor code safely with continuous validation |
+| `archon-remotion-generate` | Generate or modify a Remotion video composition |
+| `archon-resolve-conflicts` | Resolve merge conflicts in a pull request |
+| `archon-smart-pr-review` | Efficient PR review that adapts to PR size and complexity |
+| `archon-test-loop-dag` | Test loop DAG (triggered by explicit command) |
+| `archon-validate-pr` | Thorough PR validation testing both main branch and PR |
+| `archon-workflow-builder` | Create a new custom workflow for a project |
 
 These are available even when `.archon/workflows/` is empty — they ship inside the Docker image. For details on how Archon resolves custom workflows alongside built-ins, see [docs/WORKFLOW-OVERLAY.md](WORKFLOW-OVERLAY.md).
-
-> **`archon workflow list` not available.** The `archon` binary is not in the container's PATH by design — the upstream Dockerfile does not add it, so the command exits with code 127. Use the Web UI at `http://localhost:3000/workflows` to browse workflows that have been saved through the builder.
 
 ## Running a workflow from the CLI
 
@@ -278,7 +282,7 @@ Wait 20 seconds and retry `./scripts/health.sh`. The healthcheck has a `start_pe
 
 ### Workflow not found
 
-`docker compose exec app archon workflow list` is unavailable — the `archon` binary is not in the container PATH by design (the upstream Dockerfile does not add it). To check whether a workflow exists, use the Web UI at `http://localhost:3000/workflows` (for workflows with a SQLite record) or check the container filesystem directly:
+`docker compose exec app archon workflow list` is unavailable — the `archon` binary is not in the container PATH by design (the upstream Dockerfile does not add it). To check whether a workflow exists, use the Web UI at `http://localhost:3000/workflows` — in 0.3.12 this page shows all available workflows including YAML files in `.archon/workflows/`. You can also check the container filesystem directly:
 
 ```bash
 docker compose exec app ls /.archon/workflows/

--- a/docs/SHARING-WORKFLOWS.md
+++ b/docs/SHARING-WORKFLOWS.md
@@ -20,7 +20,7 @@ docker compose restart app
 
 Archon reads `.archon/workflows/` through a bind mount — the directory on your machine is directly visible inside the container. After restart, new YAML files are present in the container filesystem. See [docs/WORKFLOW-OVERLAY.md](WORKFLOW-OVERLAY.md) for the full overlay resolution model.
 
-> **YAML files delivered via `git pull` may not be discoverable immediately.** After `git pull + docker compose restart app`, the workflow YAML is delivered to the container filesystem (bind-mount confirmed) but may not be listed by all interfaces: the Web UI reads from SQLite; whether 0.3.12 scans user YAML files at startup is pending re-verification (see [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30). The `archon` CLI binary is not in the container PATH by design (`archon workflow list` exits with code 127).
+> **In 0.3.12, YAML files delivered via `git pull` are discoverable after restart.** After `git pull + docker compose restart app`, the workflow YAML is delivered to the container filesystem and **appears in the Workflows Web UI** — Archon discovers YAML files at startup (confirmed in [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30). The `archon` CLI binary is not in the container PATH by design (`archon workflow list` exits with code 127).
 
 ## Getting workflows from your team
 
@@ -56,7 +56,7 @@ docker compose exec app ls /.archon/workflows/
 
 **What you should see:** The new workflow YAML filename appears in the directory listing. This confirms the bind-mount delivered the file.
 
-> **The Web UI and CLI may not list the workflow immediately.** The Workflows page reads from SQLite (not YAML files); whether 0.3.12 scans at startup is pending re-verification. The `archon` CLI binary is not in the container PATH by design — `archon workflow list` exits with code 127. Container filesystem listing is the most reliable way to verify delivery. See [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30.
+> **The workflow appears in the Web UI after restart (0.3.12).** Archon discovers YAML files at startup — confirmed in [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30. The `archon` CLI binary is not in the container PATH by design — `archon workflow list` exits with code 127. You can also verify delivery at `http://localhost:3000/workflows`.
 
 ## Contributing a workflow
 
@@ -71,7 +71,7 @@ git commit -m "feat(workflow): add <name> workflow"
 git push
 ```
 
-**What you should see:** The push succeeds. Teammates who run `git pull` followed by `docker compose restart app` will have the YAML file delivered to the container filesystem. The Web UI reads from SQLite and the `archon` CLI binary is not in the container PATH by design — see [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30 for the confirmed finding; re-verification against 0.3.12 is pending.
+**What you should see:** The push succeeds. Teammates who run `git pull` followed by `docker compose restart app` will have the YAML file delivered to the container filesystem and **visible in the Workflows Web UI**. In 0.3.12, Archon discovers YAML files at startup — confirmed in [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30. The `archon` CLI binary is not in the container PATH by design.
 
 > **`description:` is required on every workflow YAML.** Archon's skill discovery system uses this field. A workflow without `description:` may not appear in tool lists or the Web UI.
 
@@ -123,7 +123,7 @@ See [docs/TROUBLESHOOTING.md](TROUBLESHOOTING.md) for common errors and fixes.
 
 ### Workflow not appearing after git pull + restart
 
-A workflow YAML delivered by `git pull` may not appear in the Web UI (reads from SQLite) or via `archon workflow list` (binary not in container PATH by design). Whether 0.3.12 scans at startup is pending re-verification — see [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30. Container filesystem listing (`docker compose exec app ls /.archon/workflows/`) is the most reliable way to verify the file was delivered.
+In 0.3.12, a workflow YAML delivered by `git pull` **appears in the Web UI** after `docker compose restart app` — Archon discovers YAML files at startup (see [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30). If it is not appearing, work through the checklist above. `archon workflow list` is unavailable — the binary is not in the container PATH by design.
 
 If the YAML file is not present in the container filesystem at all, check:
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -334,11 +334,10 @@ not appear in the CLI or Web UI.
 3. **Check the YAML has a `description:` field.** Open the file and verify the top-level keys
    include `description:`. Archon's workflow discovery system skips files without this field.
 
-4. **CLI and Web UI may not list git-pulled workflows.** The Web UI reads from
-   SQLite and does not scan YAML files at startup; whether 0.3.12 changed this is pending
-   re-verification (see [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30). The
-   `archon` binary is not in the container PATH by design — `archon workflow list` exits with code
-   127. Verify delivery with:
+4. **In 0.3.12, the workflow should appear in the Web UI after restart.** Archon
+   discovers YAML files at startup (confirmed — see [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30). Open `http://localhost:3000/workflows`
+   to confirm. The `archon` CLI binary is not in the container PATH by design — `archon workflow
+   list` exits with code 127. You can also verify filesystem delivery with:
 
    ```bash
    docker compose exec app ls /.archon/workflows/

--- a/docs/WORKFLOW-OVERLAY.md
+++ b/docs/WORKFLOW-OVERLAY.md
@@ -37,7 +37,7 @@ Config is single-source: /.archon/config.yaml (rw). No overlay — host copy is 
 
 **This document describes behavior at image tag `ghcr.io/coleam00/archon:0.3.12`.** Overlay precedence, restart requirements, and command discovery are version-specific. After a tag bump in `docker-compose.yml`, review the Archon release notes to confirm the contract is unchanged.
 
-> Verified against `0.3.6` on 2026-04-23 — see [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) (Test 23: scan paths — PASS; Test 24: UI write-back — PARTIAL). Re-verification against `0.3.12` pending.
+> Verified against `0.3.6` on 2026-04-23 (Tests 23, 24, 30) and `0.3.12` on 2026-05-20 (Test 30) — see [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md).
 
 ## Three ways to create or modify a workflow
 
@@ -55,7 +55,7 @@ You should see the new file listed as untracked under `.archon/workflows/`.
 
 > **Caveat — the save requires a working Claude API connection.** Archon makes an outbound call to the Claude API as part of the save process (model validation or workflow compilation). If that call hangs — for example, because `CLAUDE_CODE_OAUTH_TOKEN` is expired or not usable by Archon — the save stalls at ~89%. In this state, the YAML file is written to disk (and visible via `git status`) but the SQLite record is not written, so the workflow does not appear in Archon's Workflows UI page. If your save stalls, check your token first (see issue #25) and re-save after refreshing it.
 
-> **UI listing reads from SQLite, not YAML files.** Archon's Workflows page (`/workflows`) reads from its database, not from YAML files in `/.archon/workflows/`. A YAML file being present on disk does not guarantee the workflow appears in the UI — the database record (written on a complete save) is the authoritative source for the UI listing. A `docker compose restart app` after a complete save is sufficient for the workflow to persist across restarts; whether Archon scans `/.archon/workflows/` at startup in 0.3.12 is pending re-verification — see `.claude/docs/smoke-tests.md` Test 24.
+> **In 0.3.12, YAML files appear in the Web UI after restart.** Archon discovers YAML files in `/.archon/workflows/` at startup — a file written to disk appears in the Workflows Web UI after `docker compose restart app` (confirmed in `.claude/docs/smoke-tests.md` Test 30). If a builder save stalls at ~89% (OAuth issue), the YAML is still written to disk — a restart will surface it in the Web UI even without a complete save.
 
 After a successful save, stage and commit the YAML file to share it with the team:
 
@@ -81,7 +81,7 @@ touch .archon/workflows/my-workflow.yaml
 docker compose restart app
 ```
 
-**What you should see:** The YAML file is present in the container filesystem (bind-mount confirmed). However, the workflow **may not appear in the Web UI** — the Workflows page reads from SQLite; whether Archon scans `/.archon/workflows/` at startup in 0.3.12 is pending re-verification (see [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30). The `archon` CLI binary is not in the container PATH by design (the upstream Dockerfile does not add it), so `archon workflow list` is unavailable.
+**What you should see:** The YAML file is present in the container filesystem (bind-mount confirmed), and the workflow **appears in the Workflows Web UI** at `http://localhost:3000/workflows`. In 0.3.12, Archon discovers YAML files at startup — confirmed in [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30. The `archon` CLI binary is not in the container PATH by design (the upstream Dockerfile does not add it).
 
 ### 3. Claude Code with the Archon skill
 
@@ -108,7 +108,7 @@ Then restart the container:
 docker compose restart app
 ```
 
-**What you should see:** The override file is present in the container filesystem and takes priority for workflow execution (the bundled default is shadowed). The override does not appear in the Web UI — the Workflows page reads from SQLite, not from YAML files on disk. Confirmed in [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30.
+**What you should see:** The override file is present in the container filesystem and takes priority for workflow execution (the bundled default is shadowed). In 0.3.12, the stub also appears in the Workflows Web UI — Archon discovers YAML files at startup (see [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30).
 
 ## How to restore a default
 
@@ -122,7 +122,7 @@ docker compose restart app
 
 `git rm` stages the deletion and removes the file from disk. After the commit, teammates who run `git pull` followed by `docker compose restart app` will also see the default restored.
 
-**What you should see:** The override file is removed from the container filesystem and the bundled default is no longer suppressed for execution. The Web UI is unaffected by this change — it reads from SQLite, not from YAML files on disk.
+**What you should see:** The override file is removed from the container filesystem and the bundled default is no longer suppressed for execution. In 0.3.12, the stub entry also disappears from the Workflows Web UI after restart — Archon only discovers YAML files that exist on disk at startup.
 
 ## Git workflow after building in the UI
 
@@ -157,7 +157,7 @@ git commit -m "feat(workflow): add <name> workflow"
 git push
 ```
 
-**What you should see:** The push succeeds and teammates can `git pull` to receive the YAML file. After `docker compose restart app`, the workflow is in the container filesystem. The Web UI reads from SQLite — whether 0.3.12 scans `/.archon/workflows/` at startup is pending re-verification (see [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30). The `archon` CLI binary is not in the container PATH by design. Verify delivery with `docker compose exec app ls /.archon/workflows/`.
+**What you should see:** The push succeeds and teammates can `git pull` to receive the YAML file. After `docker compose restart app`, the workflow is in the container filesystem and **appears in the Workflows Web UI** — in 0.3.12 Archon discovers YAML files at startup (see [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30). The `archon` CLI binary is not in the container PATH by design. Verify delivery with `docker compose exec app ls /.archon/workflows/`.
 
 > **`description:` is required on every workflow YAML.** Archon's skill discovery system and the vscode-archon extension use this field to list available workflows. A workflow without `description:` may not appear in tool lists or the extension's UI.
 


### PR DESCRIPTION
## Summary

Follow-up to #40. Live verification against the running 0.3.12 container (2026-05-20) confirmed that upstream PR #1315 changed workflow discovery behavior: YAML files placed in `.archon/workflows/` are now scanned at startup and appear in the Web UI after `docker compose restart app` — no SQLite record required.

- **WORKFLOW-OVERLAY.md**: Removed 5 "pending re-verification" / "may not appear" hedges; replaced with confirmed behavior
- **SHARING-WORKFLOWS.md**: Removed 4 hedges; team sharing model stated as fully functional
- **DAILY-USE.md**: Updated built-in workflow table from 10 entries (0.3.6) to 20 (0.3.12); updated CLI caveat to direct users to Web UI for all workflows
- **TROUBLESHOOTING.md**: Updated "workflow not appearing" item to reflect confirmed discovery
- **`.claude/docs/smoke-tests.md`**: Appended 0.3.12 Test 30 PASS result (append-only per runbook)

Refs: #40