### PR TITLE
fix: replace broken CLI commands with Web UI and fix health workflow count

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,8 +27,7 @@ archon-setup/
 ├── .archon/
 │   ├── config.yaml             # Archon configuration overrides
 │   ├── workflows/              # Custom workflow YAML files (shared via git)
-│   │   ├── atyeti-pev.yaml     # Standard Plan-Execute-Validate workflow
-│   │   └── ...
+│   │   └── ...                 # Team-specific workflows (use distinct names from archon-* built-ins)
 │   └── commands/               # Custom command Markdown files (shared via git)
 │       ├── plan.md
 │       ├── execute.md
@@ -168,7 +167,7 @@ GitHub Issues with labels: `ops`, `workflow`, `docs`, `upgrade`. GitHub Flow: fe
 - **Shell functions:** `lower_snake_case` (e.g., `check_docker`, `run_backup`)
 - **Shell variables (local):** `lower_snake_case`
 - **Environment variables / constants:** `UPPER_SNAKE_CASE` (e.g., `CLAUDE_CODE_OAUTH_TOKEN`, `RCLONE_REMOTE`)
-- **YAML files:** lowercase-with-hyphens (e.g., `atyeti-pev.yaml`, `docker-compose.yml`)
+- **YAML files:** lowercase-with-hyphens (e.g., `my-workflow.yaml`, `docker-compose.yml`)
 - **Markdown doc files:** `UPPER-CASE.md` for top-level guides (e.g., `SETUP.md`, `DAILY-USE.md`)
 - **Docker Compose services:** lowercase-with-hyphens (e.g., `archon-app`, `archon-postgres`)
 - **Directories:** lowercase-with-hyphens (e.g., `archon-data`, `archon-setup`)

--- a/.claude/HANDOFF.md
+++ b/.claude/HANDOFF.md
@@ -1,34 +1,28 @@
-# Handoff — Issue #40: Bump Archon to 0.3.12 and Fix Bind Mount Paths
+# Handoff — Issue #43: Fix CLI Unavailability, Health Workflow Count, and Built-in Audit
 
 ## Goal
-Upgrade pinned Archon image from 0.3.6 to 0.3.12 and update all bind mount paths, docs, and scripts to match the unified path model introduced in upstream PR #1315.
+Three concrete gaps prevented this Archon wrapper repo from being usable in practice: (1) all `archon` CLI workflow commands in docs exit 127 (binary not in container PATH), (2) `scripts/health.sh` reported "Workflows loaded: unknown" by calling the same broken CLI, and (3) `atyeti-pev.yaml` was referenced in multiple files but does not exist.
 
 ## What Was Done
-- `docker-compose.yml`: image tag bumped to 0.3.12; workflow/command mount targets changed from `/.archon/.archon/workflows` and `/.archon/.archon/commands` to `/.archon/workflows` and `/.archon/commands`; inline comment rewritten
-- `docs/WORKFLOW-OVERLAY.md`: table, code block, and all path/caveat references updated; "Why the doubled `.archon`?" blockquote removed; version tag updated
-- `docs/DAILY-USE.md`, `docs/SHARING-WORKFLOWS.md`, `docs/TROUBLESHOOTING.md`, `docs/UPGRADING.md`, `README.md`: all path references and version-specific CLI caveats updated to version-agnostic language
-- `scripts/verify-workflow-sharing.sh`: container path and version string updated
-- README.md substantially rewritten (scope included in issue)
+
+- **`scripts/health.sh`**: Replaced `check_workflows` — removed `archon workflow list` pipeline, added `curl GET /api/workflows` + `grep -o '"name":' | wc -l` to count workflows. Added `WORKFLOWS_ENDPOINT` named constant. Now outputs `Workflows loaded: 20`.
+- **`docs/DAILY-USE.md`**: Rewrote five sections — merged "Running a workflow from the CLI/Web UI" into one Web UI-only "Running a workflow" section (step-by-step, "what you should see"); replaced broken `archon workflow status/resume/approve/reject` with Web UI + `docker compose logs`; replaced `archon isolation list/cleanup` with `docker compose exec app ls /.archon/workspaces/`; replaced `archon doctor` with `./scripts/health.sh` as primary + `bun` invocation as advanced option; streamlined "Workflow not found" troubleshooting.
+- **`docs/SHARING-WORKFLOWS.md`**: Fixed stale line-116 "what you should see" (was: `archon workflow list`; now: Web UI at `/workflows`).
+- **`docs/TROUBLESHOOTING.md`**: Removed redundant CLI sentence from "Workflow not appearing" step 4.
+- **`docs/SETUP.md`**: Removed `atyeti-pev.yaml` reference; updated "what you should see" to explain empty `.archon/workflows/` is expected.
+- **`docs/WORKFLOW-OVERLAY.md`**: Added "Built-in workflow audit" section — `archon-piv-loop` is PIV superset (no custom PEV workflow needed), `archon-workflow-builder` complements the DLC.
+- **`.claude/CLAUDE.md`**: Removed `atyeti-pev.yaml` from project structure diagram and naming convention example.
+- **`.claude/docs/smoke-tests.md`**: Appended Test 31 — CLI invocation via full path and `bun` (PARTIAL: diagnostics work, execution fails on missing Claude Code SDK native binary).
 
 ## Key Decisions
-- CLI-not-in-PATH is a permanent upstream design choice (confirmed via Dockerfile analysis), not version-specific. All docs use version-agnostic language.
-- Docs retain "pending re-verification" language for workflow discovery behavior — follow-up needed. See below.
 
-## Live Verification Findings (2026-05-20, 0.3.12)
-- Container starts cleanly; `./scripts/health.sh` passes
-- Bind mounts confirmed working at `/.archon/workflows/` and `/.archon/commands/`
-- `archon workflow list` exits 127 (by design)
-- **YAML discovery**: `verify-sharing-test.yaml` placed in `.archon/workflows/` (no SQLite record), container restarted — workflow appeared in `GET /api/workflows` response. PR #1315 unified discovery is operational.
-- API returns 20 workflow names on 0.3.12 (docs/DAILY-USE.md table lists 10 from 0.3.6)
-- Findings posted verbatim to issue #40 comment
+- **Web UI for execution, `bun` for diagnostics**: The CLI limitation is not a PATH fix — the Claude Code SDK native binary is absent from the container image. This is permanent upstream design (no fork planned). Diagnostic commands (`doctor`, `workflow list`) work via `bun /app/packages/cli/src/cli.ts` and are documented as an advanced option only.
+- **`/api/workflows` for health count**: No `jq` dependency; `grep -o '"name":' | wc -l` is sufficient.
+- **No custom `atyeti-pev.yaml`**: `archon-piv-loop` is a functional superset. `.archon/workflows/` remains empty (`.gitkeep` only) until team-specific workflows are authored.
 
 ## Current State
-PR open, targeting main. Container running on 0.3.12. Docs have "pending re-verification" language — intentionally deferred.
 
-## Next Steps
-1. Follow-up issue: update WORKFLOW-OVERLAY.md / SHARING-WORKFLOWS.md caveats to reflect confirmed YAML discovery; record 0.3.12 results in `.claude/docs/smoke-tests.md`
-2. Follow-up issue: update DAILY-USE.md built-in workflow table (20 workflows, not 10; list changed significantly)
-3. Issue #38 (open) — investigate `archon` CLI invocation alternatives in container
+PR open on `feat/issue-43-fix-resolve-cli-unavailability-broke`, targeting main. Issue #43 closes on merge. All validation passes (`shellcheck`, `validate.sh`). Container running on 0.3.12; `./scripts/health.sh` outputs `Workflows loaded: 20`.
 
 ## Issue Tracker
-- Issue #40: closes on PR merge
+- Issue #43: closes on PR merge

--- a/.claude/docs/smoke-tests.md
+++ b/.claude/docs/smoke-tests.md
@@ -409,3 +409,112 @@ Criterion-by-criterion:
 3. **Bind-mount sanity — YAML file visible in container filesystem** — **PASS**. `/.archon/workflows/verify-sharing-test.yaml` confirmed present. New path (no doubled prefix) consistent with upstream PR #1315.
 
 **Key structural finding:** In Archon 0.3.12, `git pull + docker compose restart app` delivers workflow YAML to the container filesystem AND makes it discoverable via the Web UI (`GET /api/workflows`). The git-based team-sharing model is fully functional for Web UI discoverability. CLI unavailability is unchanged — permanent upstream design decision. Documentation updated in `docs/WORKFLOW-OVERLAY.md`, `docs/SHARING-WORKFLOWS.md`, `docs/DAILY-USE.md`, and `docs/TROUBLESHOOTING.md`.
+
+---
+
+## Verification log — Archon 0.3.12 (supplemental, verified 2026-05-22)
+
+### Test 31 — CLI invocation via full path and bun
+
+**Status: PARTIAL** (verified 2026-05-22, issue #43)
+
+**What is tested:** Whether the `archon` CLI is invocable via its node_modules path or via `bun` directly, and which commands work vs. fail. This resolves the ambiguity about what "CLI unavailable" means in practice — specifically whether it is a PATH issue (fixable) or a deeper binary/SDK issue.
+
+**Commands executed:**
+
+```bash
+# Probe 1: check if archon binary exists at node_modules path
+docker compose exec -T app ls /app/node_modules/.bin/archon
+
+# Probe 2: verify bun is available and confirm CLI source path
+docker compose exec -T app which bun
+docker compose exec -T app ls /app/packages/cli/src/cli.ts
+
+# Probe 3: read-only commands via bun invocation
+docker compose exec -T app bun /app/packages/cli/src/cli.ts version
+docker compose exec -T app bun /app/packages/cli/src/cli.ts doctor
+docker compose exec -T app bun /app/packages/cli/src/cli.ts workflow list
+docker compose exec -T app bun /app/packages/cli/src/cli.ts workflow status
+docker compose exec -T app bun /app/packages/cli/src/cli.ts isolation list
+
+# Probe 4: workflow execution as root (Docker exec default)
+docker compose exec -T app bun /app/packages/cli/src/cli.ts workflow run archon-assist "test"
+
+# Probe 5: workflow execution as appuser (bypasses root check)
+docker compose exec -T --user appuser app bun /app/packages/cli/src/cli.ts workflow run archon-assist "test"
+```
+
+**Verbatim output:**
+
+```
+# Probe 1: node_modules path
+ls: /app/node_modules/.bin/archon: No such file or directory
+
+# Probe 2: runtime and source path
+/usr/local/bin/bun
+/app/packages/cli/src/cli.ts
+
+# Probe 3: read-only commands
+
+# bun ... version
+0.3.12
+
+# bun ... doctor
+✓ binary spawn
+✓ authentication
+✓ database
+✓ workspace write
+✓ bundled defaults
+
+# bun ... workflow list (20 entries, excerpt)
+archon-adversarial-dev
+archon-architect
+archon-assist
+archon-comprehensive-pr-review
+archon-create-issue
+archon-feature-development
+archon-fix-github-issue
+archon-idea-to-pr
+archon-interactive-prd
+archon-issue-review-full
+archon-piv-loop
+archon-plan-to-pr
+archon-ralph-dag
+archon-refactor-safely
+archon-remotion-generate
+archon-resolve-conflicts
+archon-smart-pr-review
+archon-test-loop-dag
+archon-validate-pr
+archon-workflow-builder
+
+# bun ... workflow status
+(empty — no active runs)
+
+# bun ... isolation list
+(empty — no active worktrees)
+
+# Probe 4: workflow run as root
+Error: Running Archon as root is not supported. Re-run with a non-root user.
+
+# Probe 5: workflow run as appuser
+error: Cannot find module '@anthropic-ai/claude-agent-sdk-linux-x64-musl/claude'
+Require stack:
+- /app/node_modules/@anthropic-ai/claude-agent-sdk/dist/index.js
+```
+
+**Classification: PARTIAL**
+
+Criterion-by-criterion:
+
+1. **`/app/node_modules/.bin/archon` exists** — **FAIL**. The path does not exist. Prior documentation referencing this path was incorrect. The CLI is not installed as a node_modules binary.
+
+2. **`bun /app/packages/cli/src/cli.ts` invocable** — **PASS**. The CLI source is at this path and is executable via Bun (the container's runtime). All read-only commands work correctly.
+
+3. **Read-only commands (`version`, `doctor`, `workflow list`, `workflow status`, `isolation list`)** — **PASS**. All exit with code 0 and produce expected output. `workflow list` returns all 20 built-in workflows.
+
+4. **Workflow execution (`workflow run`) as root** — **FAIL**. Archon rejects execution when running as root (Docker exec default). Root is not supported for workflow execution.
+
+5. **Workflow execution (`workflow run`) as appuser** — **FAIL**. Root check bypassed, but execution fails immediately on a missing Claude Code SDK native binary (`@anthropic-ai/claude-agent-sdk-linux-x64-musl/claude`). This binary is not present in the container image — it is a container image limitation, not a PATH or permissions issue.
+
+**Key structural finding:** The CLI limitation is not a PATH issue — it is a missing Claude Code SDK native binary in the container image. Diagnostic commands (`doctor`, `workflow list`, `status`, `isolation list`) all work via `bun /app/packages/cli/src/cli.ts`. Workflow execution requires the SDK native binary, which is absent from the image. The Web UI is the only workflow execution interface in the Docker deployment. This is a permanent upstream design (no fork of the image is planned — see `.claude/PLANNING.md`). Documentation in `docs/DAILY-USE.md` updated: Web UI for execution; `bun` invocation documented as an advanced troubleshooting option for diagnostic commands.

--- a/docs/DAILY-USE.md
+++ b/docs/DAILY-USE.md
@@ -124,86 +124,48 @@ Archon's built-in workflows in 0.3.12 (verified 2026-05-20):
 
 These are available even when `.archon/workflows/` is empty — they ship inside the Docker image. For details on how Archon resolves custom workflows alongside built-ins, see [docs/WORKFLOW-OVERLAY.md](WORKFLOW-OVERLAY.md).
 
-## Running a workflow from the CLI
+## Running a workflow
 
-```bash
-docker compose exec app archon workflow run <name> "<message>"
-```
-
-Examples:
-
-```bash
-# Ask a question about the codebase
-docker compose exec app archon workflow run archon-assist "What does the orchestrator do?"
-
-# Fix a GitHub issue with an isolated worktree branch
-docker compose exec app archon workflow run archon-fix-github-issue --branch fix/login-crash "#142"
-```
-
-Archon streams AI reasoning to the terminal as it runs. Use `--quiet` to suppress streaming output or `--verbose` for tool-level events.
-
-Key flags:
-
-| Flag | Description |
-|---|---|
-| `--branch <name>` | Create an isolated git worktree on this branch (default behavior: runs in isolated worktree) |
-| `--no-worktree` | Run directly in the live checkout instead of an isolated worktree |
-| `--verbose` | Stream tool-level events (file reads, writes, shell commands) |
-| `--quiet` | Suppress streaming output; show only the final result |
-| `--resume` | Resume an interrupted run, skipping already-completed nodes |
-
-> **Worktree isolation is on by default.** Workflows run in isolated git worktrees at `~/.archon/workspaces/` inside the container. This keeps experiments off your main branch. Use `--no-worktree` only when you want the workflow to modify your live working directory.
-
-Workflow name matching is fuzzy: exact → case-insensitive → suffix → substring. For example, `archon workflow run assist` resolves to `archon-assist`.
-
-## Running a workflow from the Web UI
+Workflow execution requires the Web UI — the `archon` CLI binary is not in the container PATH by design (the upstream Dockerfile does not add it), so `archon workflow run` exits with code 127.
 
 Open `http://localhost:3000` in your browser.
 
-> If you changed the `PORT` variable in `.env`, use that port number: `http://localhost:<PORT>`.
+> If you changed the `PORT` variable in `.env`, use that port number instead: `http://localhost:<PORT>`.
 
-The Web UI provides a chat-style interface for working with Archon. Key pages:
+**How to run a workflow:**
 
-- **`/workflows`** — lists workflows that have a SQLite record (see note in [Listing available workflows](#listing-available-workflows))
+1. Open `http://localhost:3000` in your browser.
+2. Navigate to the **Workflows** page (sidebar or `/workflows`).
+3. Click the workflow you want to run — for example, `archon-assist` for general tasks or `archon-fix-github-issue` for GitHub issue work.
+4. Type your request or task description in the chat input and press **Run** (or **Enter**).
+
+**What you should see:** Archon streams its reasoning and tool calls in real time as the workflow progresses. The final result appears when the workflow completes. Workflows that create pull requests print the PR URL in the output.
+
+Key pages in the Web UI:
+
+- **`/workflows`** — lists all available workflows (built-in + any custom YAML files in `.archon/workflows/`)
 - **`/workflows/builder`** — create or edit a workflow using the visual builder
 - **`+ New Workflow`** button on the Workflows page — shortcut to the builder
 
 ## Checking workflow status
 
-Show all currently running workflow runs:
+All active workflow runs are visible in the Web UI at `http://localhost:3000`. Click a run to see its current status, live output, and any pending approval gates. Resume, approve, and reject operations are also handled in the Web UI — the `archon workflow resume/approve/reject` CLI commands are not available in the container.
 
-```bash
-docker compose exec app archon workflow status
-```
-
-**What you should see:** A table of active runs with run IDs, workflow names, and status. Empty output means nothing is currently running.
-
-To resume a run that was interrupted:
-
-```bash
-docker compose exec app archon workflow resume <run-id>
-```
-
-To approve or reject a workflow at an approval gate:
-
-```bash
-docker compose exec app archon workflow approve <run-id>
-docker compose exec app archon workflow reject <run-id>
-```
-
-For container-level logs when a run is missing from `status`:
+For container-level logs — useful when a run is not appearing in the Web UI or you want the raw output stream:
 
 ```bash
 docker compose logs -f app
 ```
 
+**What you should see:** Each line is prefixed with `archon-app  |`. Running workflows emit reasoning and tool-call lines in real time. Press `Ctrl+C` to stop streaming. Remove `-f` to print existing logs and exit immediately.
+
 ## Viewing results
 
-CLI runs stream output to the terminal in real time. The final result prints when the workflow completes.
+Workflow output streams in the Web UI in real time. The final result appears when the workflow completes.
 
 Multi-step workflows pass output between steps using artifact files (for example, `investigation.md` or `implementation.md`). These are stored inside the workflow's worktree directory under `~/archon-data/` on your host.
 
-Workflows that create pull requests print the PR URL on completion:
+Workflows that create pull requests show the PR URL in the output on completion:
 
 ```
 ✓ Pull request created: https://github.com/<org>/<repo>/pull/<number>
@@ -211,34 +173,46 @@ Workflows that create pull requests print the PR URL on completion:
 
 Archon stores all workflow state in `~/archon-data/archon.db` (SQLite). Active worktrees live under `~/archon-data/`.
 
-To list active worktrees or clean up stale ones:
+To inspect active worktrees inside the container:
 
 ```bash
-docker compose exec app archon isolation list
-docker compose exec app archon isolation cleanup
+docker compose exec app ls /.archon/workspaces/
 ```
+
+**What you should see:** A list of workspace directory names, one per active workflow run. Each directory is an isolated git worktree. Check the Web UI for active run status before removing anything manually.
 
 ## Validating your setup
 
-Run Archon's built-in diagnostic:
+Run the health check script as your primary diagnostic:
 
 ```bash
-docker compose exec app archon doctor
+./scripts/health.sh
 ```
-
-`archon doctor` checks: binary spawn, authentication, database connectivity, workspace writability, and bundled defaults.
 
 **What you should see:**
 
 ```
-✓ binary spawn
-✓ authentication
-✓ database
-✓ workspace write
-✓ bundled defaults
+archon-app: running (healthy) | Archon API: OK | Workflows loaded: 20
 ```
 
-Any `✗` line indicates a specific failure. An authentication failure usually means the OAuth token in `.env` is expired — re-run `./scripts/setup-oauth.sh` to refresh it.
+The script checks three things: the container is running, the `/api/health` endpoint responds, and the workflow count (informational). If any gate fails, the script explains what to fix. See [docs/TROUBLESHOOTING.md](TROUBLESHOOTING.md) for detailed error recovery.
+
+> **Advanced — internal health checks:** For low-level diagnostics (database connectivity, workspace writability, bundled defaults), use Bun to invoke the CLI source directly inside the container:
+>
+> ```bash
+> docker compose exec -T app bun /app/packages/cli/src/cli.ts doctor
+> ```
+>
+> **What you should see:**
+> ```
+> ✓ binary spawn
+> ✓ authentication
+> ✓ database
+> ✓ workspace write
+> ✓ bundled defaults
+> ```
+>
+> Any `✗` line indicates a specific failure. An authentication failure usually means the OAuth token in `.env` is expired — re-run `./scripts/setup-oauth.sh` to refresh it. This uses Bun (the container's runtime) to call the CLI source — the `archon` binary is not in the container PATH by design.
 
 ## Restarting after configuration changes
 
@@ -282,10 +256,14 @@ Wait 20 seconds and retry `./scripts/health.sh`. The healthcheck has a `start_pe
 
 ### Workflow not found
 
-`docker compose exec app archon workflow list` is unavailable — the `archon` binary is not in the container PATH by design (the upstream Dockerfile does not add it). To check whether a workflow exists, use the Web UI at `http://localhost:3000/workflows` — in 0.3.12 this page shows all available workflows including YAML files in `.archon/workflows/`. You can also check the container filesystem directly:
+Open `http://localhost:3000/workflows` — in 0.3.12, this page shows all available workflows including built-ins and any custom YAML files in `.archon/workflows/`. To confirm the file reached the container filesystem:
 
 ```bash
 docker compose exec app ls /.archon/workflows/
 ```
 
-If a custom workflow is missing from that listing, confirm the YAML file is in `.archon/workflows/` on your host and the container was restarted after the file was added.
+If a custom workflow is missing, confirm the YAML file is in `.archon/workflows/` on your host and that you restarted the container after adding it:
+
+```bash
+docker compose restart app
+```

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -224,9 +224,7 @@ visible from the host:
 ls .archon/workflows/
 ```
 
-**What you should see:** At least `atyeti-pev.yaml` listed. If the directory appears empty,
-the bind mount may not have taken effect — see
-[`docs/TROUBLESHOOTING.md`](TROUBLESHOOTING.md).
+**What you should see:** The directory may contain only `.gitkeep` if no custom workflows have been added yet — this is expected. The 20 built-in Archon workflows ship inside the Docker image and are always available without any files in this directory. If the command returns an error (no such directory or permission denied), the bind mount may not have taken effect — see [`docs/TROUBLESHOOTING.md`](TROUBLESHOOTING.md).
 
 Finally, open `http://localhost:3000` in your browser to access the Archon web UI.
 

--- a/docs/SHARING-WORKFLOWS.md
+++ b/docs/SHARING-WORKFLOWS.md
@@ -113,7 +113,7 @@ git commit -m "chore(workflow): suppress built-in <filename>"
 git push
 ```
 
-**What you should see:** After the restart, `docker compose exec app archon workflow list` no longer shows the suppressed workflow. The stub override takes its place.
+**What you should see:** After the restart, open `http://localhost:3000/workflows` — the suppressed workflow no longer appears (it has been replaced by the stub). The `archon` CLI binary is not in the container PATH by design — `archon workflow list` exits with code 127.
 
 For the full overlay resolution order and instructions on restoring a suppressed default, see [docs/WORKFLOW-OVERLAY.md](WORKFLOW-OVERLAY.md).
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -336,8 +336,7 @@ not appear in the CLI or Web UI.
 
 4. **In 0.3.12, the workflow should appear in the Web UI after restart.** Archon
    discovers YAML files at startup (confirmed — see [`.claude/docs/smoke-tests.md`](../.claude/docs/smoke-tests.md) Test 30). Open `http://localhost:3000/workflows`
-   to confirm. The `archon` CLI binary is not in the container PATH by design — `archon workflow
-   list` exits with code 127. You can also verify filesystem delivery with:
+   to confirm. You can also verify filesystem delivery with:
 
    ```bash
    docker compose exec app ls /.archon/workflows/

--- a/docs/WORKFLOW-OVERLAY.md
+++ b/docs/WORKFLOW-OVERLAY.md
@@ -167,6 +167,22 @@ The read-write mount gives the Archon container write authority over `.archon/wo
 
 No secrets belong in `.archon/workflows/` or `.archon/commands/`. Both directories are git-tracked. The OAuth token lives in `.env`, which is `.gitignore`'d and injected via `env_file:` in `docker-compose.yml`.
 
+## Built-in workflow audit (verified 2026-05-22)
+
+Archon 0.3.12 ships 20 built-in workflows. Two were audited against this team's development workflow:
+
+### `archon-piv-loop`
+
+A 5-phase interactive loop: EXPLORE → PLAN → IMPLEMENT → VALIDATE → FINALIZE. This is a superset of the Plan-Execute-Validate concept — it adds an upfront exploration phase and an explicit finalization phase. **No custom Plan-Execute-Validate workflow is needed.** Use `archon-piv-loop` from the Web UI for full-cycle feature development.
+
+### `archon-workflow-builder`
+
+Creates a custom workflow YAML file via AI-guided intent extraction — you describe what you want a workflow to do, and Archon generates the YAML. This **complements** the DLC authoring flow (which covers general feature development in Claude Code) rather than replacing it. Use `archon-workflow-builder` when you want to create a new reusable Archon workflow for a specific project pattern.
+
+### Decision: `.archon/workflows/` reserved for team-specific workflows
+
+No custom workflows duplicate the 20 built-ins. `.archon/workflows/` is reserved for team-specific workflows that extend the built-ins — workflows that encode team conventions, project-specific patterns, or custom automation not covered by the defaults. Use **distinct filenames** (not starting with `archon-`) to avoid shadowing built-ins.
+
 ## Something went wrong?
 
 See [`docs/TROUBLESHOOTING.md`](TROUBLESHOOTING.md) for common errors and fixes.

--- a/scripts/health.sh
+++ b/scripts/health.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PROJECT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
 readonly DEFAULT_PORT=3000
 readonly HEALTH_ENDPOINT="/api/health"
+readonly WORKFLOWS_ENDPOINT="/api/workflows"
 readonly CONTAINER_NAME="archon-app"
 
 # Global state written by each check function; read by main() for the summary line.
@@ -97,16 +98,18 @@ check_api() {
 
 # Informational only — workflow count is never a health gate.
 check_workflows() {
+  local port="${PORT:-${DEFAULT_PORT}}"
+  local url="http://localhost:${port}${WORKFLOWS_ENDPOINT}"
   echo "→ Checking loaded workflows..."
 
-  local raw_count
-  if raw_count=$(docker compose -f "${PROJECT_DIR}/docker-compose.yml" exec -T app archon workflow list 2>/dev/null | wc -l | tr -d ' '); then
-    WORKFLOW_COUNT="${raw_count}"
-    echo "  Workflows loaded: ${WORKFLOW_COUNT}"
+  local response count
+  if response=$(curl -sf --max-time 5 "$url" 2>/dev/null); then
+    count=$(printf '%s' "$response" | grep -o '"name":' | wc -l | tr -d ' ') || count="0"
+    WORKFLOW_COUNT="${count}"
   else
     WORKFLOW_COUNT="unknown"
-    echo "  Workflows loaded: unknown"
   fi
+  echo "  Workflows loaded: ${WORKFLOW_COUNT}"
 }
 
 main() {


### PR DESCRIPTION
## Summary

- Replace `check_workflows` in `scripts/health.sh` — was calling `archon workflow list` (exit 127); now calls `curl GET /api/workflows` and counts `"name":` keys. Output changes from "unknown" to "20".
- Rewrite broken CLI sections in `docs/DAILY-USE.md` — `archon workflow run/status/resume/approve/reject/doctor/isolation` all replaced with Web UI instructions and `./scripts/health.sh`; add `bun /app/packages/cli/src/cli.ts doctor` as advanced diagnostic callout.
- Fix stale `atyeti-pev.yaml` references in `docs/SETUP.md`, `.claude/CLAUDE.md`, and `docs/SHARING-WORKFLOWS.md` — file never existed on disk.
- Document built-in workflow audit in `docs/WORKFLOW-OVERLAY.md` — `archon-piv-loop` supersedes the Plan-Execute-Validate concept; no custom duplicates needed.
- Add Test 31 to `.claude/docs/smoke-tests.md` — CLI invocation via full path and bun (PARTIAL: diagnostics work, execution fails on missing SDK native binary).

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)