### PR TITLE
fix(ops): remove CLI probe and fix classification in verify-workflow-sharing.sh

### DIFF
--- a/.claude/HANDOFF.md
+++ b/.claude/HANDOFF.md
@@ -1,33 +1,35 @@
-# Handoff — Issue #45: Fix stale SQLite discovery claim in docs
+# Handoff — Issue #46: Fix verify-workflow-sharing.sh for 0.3.12
 
 ## Goal
 
-Three documentation files carried a 0.3.6-era claim that a workflow builder save stalling at ~89% leaves the workflow invisible in the Web UI until the token is fixed and the save retried. In 0.3.12, YAML files are discovered at startup — a `docker compose restart app` surfaces the workflow immediately without a SQLite record.
+Fix three bugs in `scripts/verify-workflow-sharing.sh` that caused the script to always report `PARTIAL` on a healthy 0.3.12 system:
+1. CLI probe permanently exits 127 (upstream packaging decision) — classification never reached PASS
+2. Stale 0.3.6 error message in `probe_api()` claiming YAML is not scanned at startup (false in 0.3.12)
+3. Stale "Record in Test 30" instruction (already recorded for both 0.3.6 and 0.3.12)
 
 ## What Was Done
 
-Updated five occurrences across three docs:
+Single file changed: `scripts/verify-workflow-sharing.sh`
 
-| File | Location | Change |
-|------|----------|--------|
-| `docs/DAILY-USE.md` | Line 242 + fix guidance | Stale claim removed; restart-discovery language added; fix guidance opens with restart-first workaround |
-| `docs/SHARING-WORKFLOWS.md` | Line 92 blockquote | Stale "not in Web UI" claim → restart-discovery language |
-| `docs/SHARING-WORKFLOWS.md` | Line 136 subsection | Same replacement |
-| `docs/TROUBLESHOOTING.md` | Cause paragraph | Stale "does not appear" claim → restart-discovery language |
-| `docs/TROUBLESHOOTING.md` | Fix section opening | Added restart-first step (review WARN: Cause said restart helps, Fix didn't echo it) |
-
-`docs/WORKFLOW-OVERLAY.md` intentionally untouched — already correct, served as reference language.
+| Change | Detail |
+|--------|--------|
+| Removed `probe_cli()` | 46-line function deleted; `archon` binary absent by upstream design |
+| Removed `CLI_RESULT` global | No orphaned references remain |
+| Rewrote classification | 2-axis (API + mount); returns PASS when both pass |
+| Fixed `probe_api()` error message | Version-neutral: `"Workflow not discovered — check container logs: docker compose logs app"` |
+| Updated `usage()` | Lists 2 checks (was 3); no CLI mention |
+| Renumbered `probe_mount()` | "Check 3" → "Check 2" |
+| Replaced Test 30 instruction | Now: `"Append this result to .claude/docs/smoke-tests.md if testing a new Archon image tag."` |
 
 ## Key Decisions
 
-- **Restart-first ordering**: Fix guidance leads with `docker compose restart app` (immediate relief) before `setup-oauth.sh + retry` (permanent fix). Mirrors the DAILY-USE.md pattern.
-- **TROUBLESHOOTING.md Fix section**: PRP scoped to Cause only, but review WARN found the Fix section asymmetric with the updated Cause. One-line addition front-loads the restart — consistent with all other updated locations. Issue #46 is unrelated (script bug), so fix was included here.
-- **WORKFLOW-OVERLAY.md out of scope**: PRP CRITICAL — lines 56-58 intentionally hold both old caveat and 0.3.12 correction side-by-side as a layered explanation.
+- **CLI probe removed, not patched**: Test 31 in smoke-tests.md confirms `archon` binary is absent by upstream design. Any gate on CLI would permanently block PASS — removal is the only correct fix.
+- **Classification reduced to 2-axis**: Mount probe preserved because it validates Docker Compose volume config independently of Archon's application-level discovery.
 
 ## Current State
 
-All changes committed and pushed. PR open on `feat/issue-45-fix-stale-sqlite-discovery-claim`. Issue #45 closes on merge. Validation passes (4/4, 2 skipped).
+All changes committed and pushed. PR open on `feat/issue-46-fix-ops-update-verify-workflow-sharing-for-0-3-12`. Issue #46 closes on merge. Validation: 4/4 passed, 2 skipped.
 
 ## Next Steps
 
-- **Issue #46** (open): Update `scripts/verify-workflow-sharing.sh` for 0.3.12. Three bugs: classification always yields PARTIAL (API=PASS + CLI=UNAVAILABLE), stale error message in `probe_api()`, stale "Record in Test 30" instruction. Recommendation: remove CLI probe, rewrite classification as API+mount only.
+No open issues remain after #46 merges. Check `gh issue list --state open` for new backlog items.

--- a/scripts/verify-workflow-sharing.sh
+++ b/scripts/verify-workflow-sharing.sh
@@ -12,7 +12,6 @@ readonly HEALTH_INTERVAL=5
 
 # Written by each probe function; read by print_summary.
 API_RESULT="not run"
-CLI_RESULT="not run"
 MOUNT_RESULT="not run"
 
 cleanup() {
@@ -32,13 +31,12 @@ usage() {
 Usage: $(basename "$0") [--help]
 
 Tests whether a hand-placed YAML file in .archon/workflows/ appears in
-Archon's Web UI (/api/workflows) and CLI (archon workflow list) after
-docker compose restart app. Verifies the git-pull team-sharing model.
+Archon's Web UI (/api/workflows) after docker compose restart app.
+Verifies the git-pull team-sharing model.
 
 Checks performed:
   1. API probe     — GET /api/workflows, search for test workflow name
-  2. CLI probe     — archon workflow list inside container, stdout+stderr captured
-  3. Bind-mount    — confirm file visible inside container at expected path
+  2. Bind-mount    — confirm file visible inside container at expected path
 
 Exit codes:
   0 — test ran to completion (PASS/FAIL/PARTIAL reported, not an exit code)
@@ -165,61 +163,13 @@ probe_api() {
   else
     API_RESULT="FAIL"
     echo "  ✗ '${TEST_WORKFLOW_NAME}' not found in API response"
-    echo "    UI Workflows page reads from SQLite — hand-placed YAML is not scanned at startup"
-  fi
-}
-
-probe_cli() {
-  echo "→ Check 2 — CLI probe: archon workflow list (inside container)"
-  local tmp_stderr cli_stdout="" cli_exit=0
-  tmp_stderr=$(mktemp)
-
-  cli_stdout=$(docker compose -f "${PROJECT_DIR}/docker-compose.yml" exec -T app \
-    archon workflow list 2>"$tmp_stderr") || cli_exit=$?
-  local cli_stderr
-  cli_stderr=$(cat "$tmp_stderr" 2>/dev/null || true)
-  rm -f "$tmp_stderr"
-
-  echo "  stdout: ${cli_stdout:-(empty)}"
-  if [ -n "$cli_stderr" ]; then
-    echo "  stderr: ${cli_stderr}"
-  fi
-  if [ "$cli_exit" -ne 0 ]; then
-    echo "  exit code: ${cli_exit}"
-  fi
-
-  # Exit code 127 = command not found (POSIX standard for exec failures)
-  if [ "$cli_exit" -eq 127 ]; then
-    CLI_RESULT="UNAVAILABLE"
-    echo "  ✗ CLI command unavailable (exit 127 — binary not found in container PATH)"
-    return
-  fi
-
-  if echo "${cli_stdout}${cli_stderr}" | grep -qiE \
-    "command not found|unknown command|is not a.*command|executable file not found|OCI runtime exec failed"; then
-    CLI_RESULT="UNAVAILABLE"
-    echo "  ✗ CLI command unavailable (not found / exec failed)"
-    return
-  fi
-
-  if [ "$cli_exit" -ne 0 ] && [ -z "$cli_stdout" ]; then
-    CLI_RESULT="UNAVAILABLE"
-    echo "  ✗ CLI command exited ${cli_exit} with no output — may not be supported in this version"
-    return
-  fi
-
-  if echo "$cli_stdout" | grep -q "${TEST_WORKFLOW_NAME}"; then
-    CLI_RESULT="PASS"
-    echo "  ✓ '${TEST_WORKFLOW_NAME}' found in CLI output"
-  else
-    CLI_RESULT="FAIL"
-    echo "  ✗ '${TEST_WORKFLOW_NAME}' not found in CLI output"
+    echo "    Workflow not discovered — check container logs: docker compose logs app"
   fi
 }
 
 probe_mount() {
   local container_path="/.archon/workflows/${TEST_WORKFLOW_NAME}.yaml"
-  echo "→ Check 3 — Bind-mount: ${container_path} in container"
+  echo "→ Check 2 — Bind-mount: ${container_path} in container"
 
   if docker compose -f "${PROJECT_DIR}/docker-compose.yml" exec -T app \
     ls "$container_path" &>/dev/null 2>&1; then
@@ -237,20 +187,21 @@ print_summary() {
   echo " verify-workflow-sharing.sh — Archon 0.3.12 result"
   echo "══════════════════════════════════════════════════════════════════"
   echo " API (UI data source): ${API_RESULT}"
-  echo " CLI:                  ${CLI_RESULT}"
   echo " Bind-mount:           ${MOUNT_RESULT}"
   echo "══════════════════════════════════════════════════════════════════"
 
-  if [ "${API_RESULT}" = "PASS" ] && [ "${CLI_RESULT}" = "PASS" ]; then
-    echo " Classification: PASS — workflow visible in both UI (API) and CLI"
-  elif [ "${API_RESULT}" = "PASS" ] || [ "${CLI_RESULT}" = "PASS" ]; then
-    echo " Classification: PARTIAL — one channel sees the workflow, other does not"
+  if [ "${API_RESULT}" = "PASS" ] && [ "${MOUNT_RESULT}" = "PASS" ]; then
+    echo " Classification: PASS — workflow visible in Web UI and mounted correctly"
+  elif [ "${API_RESULT}" = "PASS" ]; then
+    echo " Classification: PARTIAL — API sees workflow but bind-mount check failed"
+  elif [ "${MOUNT_RESULT}" = "PASS" ]; then
+    echo " Classification: PARTIAL — file mounted but not discovered by Archon"
   else
-    echo " Classification: FAIL — hand-placed YAML not visible via API or CLI"
+    echo " Classification: FAIL — hand-placed YAML not visible via API and mount check failed"
   fi
 
   echo ""
-  echo " Record this output verbatim in .claude/docs/smoke-tests.md (Test 30)."
+  echo " Append this result to .claude/docs/smoke-tests.md if testing a new Archon image tag."
 }
 
 main() {
@@ -273,7 +224,6 @@ main() {
   }
 
   probe_api
-  probe_cli
   probe_mount
   print_summary
 }


### PR DESCRIPTION
## Summary

- Remove `probe_cli()` and `CLI_RESULT` global — the `archon` binary is absent from the container PATH by upstream packaging decision, making the CLI axis permanently UNAVAILABLE and the old API+CLI classification structurally incapable of returning PASS
- Rewrite `print_summary()` to 2-axis classification (API + mount); correctly reports PASS on a healthy 0.3.12 system where both probes pass
- Replace stale `probe_api()` failure message (`"hand-placed YAML is not scanned at startup"`) with version-neutral diagnostic hint — the 0.3.6 claim is false in 0.3.12 since upstream PR #1315 unified workflow discovery
- Replace stale "Record in Test 30" instruction with version-scoped guidance: append to smoke-tests.md only when testing a new image tag

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)