### PR TITLE
feat(infra): automate first deploy via GitHub Actions

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -1,0 +1,170 @@
+name: Infrastructure
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Terraform action"
+        required: true
+        default: "apply"
+        type: choice
+        options:
+          - apply
+          - plan
+          - destroy
+
+concurrency:
+  group: infrastructure
+  cancel-in-progress: false
+
+env:
+  TF_DIR: terraform
+  GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
+  TF_STATE_BUCKET: archon-tfstate
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Create state bucket if needed
+        run: |
+          if ! gcloud storage buckets describe "gs://${TF_STATE_BUCKET}" --project="${GCP_PROJECT}" &>/dev/null; then
+            echo "→ Creating state bucket gs://${TF_STATE_BUCKET}"
+            gcloud storage buckets create "gs://${TF_STATE_BUCKET}" \
+              --project="${GCP_PROJECT}" \
+              --location=us-central1 \
+              --uniform-bucket-level-access
+            gcloud storage buckets update "gs://${TF_STATE_BUCKET}" \
+              --versioning
+          else
+            echo "✓ State bucket already exists"
+          fi
+
+      - name: Write terraform.tfvars
+        working-directory: ${{ env.TF_DIR }}
+        env:
+          TF_VAR_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
+          TF_VAR_EMAIL: ${{ secrets.OAUTH_EMAIL }}
+        run: |
+          printf '%s\n' \
+            "gcp_project_id = \"${TF_VAR_PROJECT}\"" \
+            "oauth_email    = \"${TF_VAR_EMAIL}\"" \
+            "" \
+            "archon_instances = {" \
+            "  chris = {" \
+            "    secrets_map = {" \
+            "      claude_oauth_token   = \"archon-chris-claude-oauth-token\"" \
+            "      github_token         = \"archon-chris-github-token\"" \
+            "      discord_bot_token    = \"archon-chris-discord-bot-token\"" \
+            "      oauth2_client_id     = \"archon-chris-oauth2-client-id\"" \
+            "      oauth2_client_secret = \"archon-chris-oauth2-client-secret\"" \
+            "    }" \
+            "  }" \
+            "}" > terraform.tfvars
+
+      - name: Terraform Init
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform init
+
+      - name: Terraform Plan
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform plan -out=tfplan
+
+      - name: Terraform Apply
+        if: inputs.action == 'apply'
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform apply -auto-approve tfplan
+
+      - name: Terraform Destroy
+        if: inputs.action == 'destroy'
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform destroy -auto-approve
+
+      - name: Extract outputs
+        if: inputs.action == 'apply'
+        id: outputs
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          INSTANCE_IP=$(terraform output -json instance_ips | jq -r '.chris')
+          SSLIP_DOMAIN=$(terraform output -json sslip_domains | jq -r '.chris')
+
+          echo "instance_ip=${INSTANCE_IP}" >> "$GITHUB_OUTPUT"
+          echo "sslip_domain=${SSLIP_DOMAIN}" >> "$GITHUB_OUTPUT"
+
+          terraform output -json ssh_private_keys | jq -r '.chris' > /tmp/ssh_key.pem
+          chmod 600 /tmp/ssh_key.pem
+
+      - name: Set deploy secrets
+        if: inputs.action == 'apply'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "→ Setting DEPLOY_HOST and DEPLOY_SSH_KEY secrets"
+          echo -n "${{ steps.outputs.outputs.instance_ip }}" | gh secret set DEPLOY_HOST
+          cat /tmp/ssh_key.pem | gh secret set DEPLOY_SSH_KEY
+          echo "✓ Deploy secrets updated"
+
+      - name: Wait for VM startup
+        if: inputs.action == 'apply'
+        run: |
+          echo "→ Waiting 180s for VM startup script to complete..."
+          sleep 180
+
+      - name: Verify VM is reachable
+        if: inputs.action == 'apply'
+        run: |
+          echo "→ Checking SSH connectivity..."
+          for i in $(seq 1 6); do
+            if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+              -i /tmp/ssh_key.pem \
+              "chris@${{ steps.outputs.outputs.instance_ip }}" \
+              "echo 'SSH OK'" 2>/dev/null; then
+              echo "✓ VM is reachable via SSH"
+              exit 0
+            fi
+            echo "  Attempt ${i}/6 failed, waiting 30s..."
+            sleep 30
+          done
+          echo "✗ VM not reachable after 6 attempts"
+          exit 1
+
+      - name: Summary
+        if: inputs.action == 'apply'
+        run: |
+          DOMAIN="${{ steps.outputs.outputs.sslip_domain }}"
+          {
+            echo "## Infrastructure Deployed"
+            echo ""
+            echo "- **IP:** \`${{ steps.outputs.outputs.instance_ip }}\`"
+            echo "- **Domain:** \`https://${DOMAIN}\`"
+            echo ""
+            echo "### Required manual step"
+            echo "Update the OAuth redirect URI in [Google Cloud Console](https://console.cloud.google.com/apis/credentials?project=${{ secrets.GCP_PROJECT_ID }}):"
+            echo "\`\`\`"
+            echo "https://${DOMAIN}/oauth2/callback"
+            echo "\`\`\`"
+            echo ""
+            echo "### Access"
+            echo "Open \`https://${DOMAIN}\` — Google login should appear."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Cleanup
+        if: always()
+        run: rm -f /tmp/ssh_key.pem

--- a/scripts/setup-gcp-ci.sh
+++ b/scripts/setup-gcp-ci.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --project PROJECT_ID --email OAUTH_EMAIL [--help]
+
+One-time setup: creates a GCP service account for GitHub Actions, grants it
+the required IAM roles, generates a key, and stores it as a GitHub secret.
+
+Prerequisites:
+  - gcloud CLI authenticated as project owner
+  - gh CLI authenticated with repo access
+
+Required arguments:
+  --project    GCP project ID
+  --email      OAuth email (for OAUTH_EMAIL secret)
+
+Exit codes:
+  0 — setup complete
+  1 — missing tool or failure
+EOF
+}
+
+check_deps() {
+  local missing=0
+  for cmd in gcloud gh; do
+    if ! command -v "$cmd" &>/dev/null; then
+      echo "✗ Required tool not found: $cmd" >&2
+      missing=1
+    fi
+  done
+  if [ "$missing" -ne 0 ]; then
+    exit 1
+  fi
+}
+
+PROJECT_ID=""
+OAUTH_EMAIL=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project) PROJECT_ID="$2"; shift 2 ;;
+    --email) OAUTH_EMAIL="$2"; shift 2 ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "✗ Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [ -z "$PROJECT_ID" ] || [ -z "$OAUTH_EMAIL" ]; then
+  echo "✗ --project and --email are required" >&2
+  usage
+  exit 1
+fi
+
+check_deps
+
+SA_NAME="archon-ci"
+SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+echo "→ Creating service account ${SA_NAME}..."
+if gcloud iam service-accounts describe "$SA_EMAIL" --project="$PROJECT_ID" &>/dev/null; then
+  echo "  Already exists, skipping creation"
+else
+  gcloud iam service-accounts create "$SA_NAME" \
+    --display-name="Archon CI — GitHub Actions" \
+    --project="$PROJECT_ID"
+fi
+
+ROLES=(
+  "roles/compute.admin"
+  "roles/secretmanager.admin"
+  "roles/iam.serviceAccountAdmin"
+  "roles/iam.serviceAccountUser"
+  "roles/storage.admin"
+)
+
+echo "→ Granting IAM roles..."
+for role in "${ROLES[@]}"; do
+  echo "  → ${role}"
+  gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+    --member="serviceAccount:${SA_EMAIL}" \
+    --role="$role" \
+    --condition=None \
+    --quiet >/dev/null
+done
+echo "✓ IAM roles granted"
+
+KEY_FILE=$(mktemp)
+echo "→ Creating service account key..."
+gcloud iam service-accounts keys create "$KEY_FILE" \
+  --iam-account="$SA_EMAIL" \
+  --project="$PROJECT_ID"
+
+echo "→ Setting GitHub secrets..."
+gh secret set GCP_SA_KEY < "$KEY_FILE"
+echo -n "$PROJECT_ID" | gh secret set GCP_PROJECT_ID
+echo -n "$OAUTH_EMAIL" | gh secret set OAUTH_EMAIL
+echo "✓ GitHub secrets set: GCP_SA_KEY, GCP_PROJECT_ID, OAUTH_EMAIL"
+
+rm -f "$KEY_FILE"
+echo ""
+echo "✓ CI setup complete. Trigger the Infrastructure workflow from GitHub Actions."

--- a/scripts/setup-gcp-secrets.sh
+++ b/scripts/setup-gcp-secrets.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --project PROJECT_ID [--help]
+
+Interactive setup for all GCP Secret Manager secrets required by Archon.
+Prompts for each secret value, creates or updates the secret.
+
+Required arguments:
+  --project    GCP project ID
+
+Exit codes:
+  0 — all secrets created/updated
+  1 — failure
+EOF
+}
+
+PROJECT_ID=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project) PROJECT_ID="$2"; shift 2 ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "✗ Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [ -z "$PROJECT_ID" ]; then
+  echo "✗ --project is required" >&2
+  usage
+  exit 1
+fi
+
+if ! command -v gcloud &>/dev/null; then
+  echo "✗ gcloud not found" >&2
+  exit 1
+fi
+
+create_or_update_secret() {
+  local name="$1"
+  local value="$2"
+
+  if gcloud secrets describe "$name" --project="$PROJECT_ID" &>/dev/null; then
+    echo -n "$value" | gcloud secrets versions add "$name" --data-file=- --project="$PROJECT_ID"
+    echo "  ✓ Updated ${name}"
+  else
+    echo -n "$value" | gcloud secrets create "$name" --data-file=- --project="$PROJECT_ID"
+    echo "  ✓ Created ${name}"
+  fi
+}
+
+SECRETS=(
+  "archon-chris-claude-oauth-token|Claude OAuth token (sk-ant-oat-...)"
+  "archon-chris-github-token|GitHub fine-grained PAT (github_pat_...)"
+  "archon-chris-discord-bot-token|Discord bot token"
+  "archon-chris-oauth2-client-id|Google OAuth2 Client ID (from GCP Console Credentials)"
+  "archon-chris-oauth2-client-secret|Google OAuth2 Client Secret"
+)
+
+echo "→ Setting up GCP secrets for project ${PROJECT_ID}"
+echo "  Press Enter to skip any secret that's already set."
+echo ""
+
+for entry in "${SECRETS[@]}"; do
+  IFS='|' read -r name description <<< "$entry"
+
+  existing=""
+  if gcloud secrets describe "$name" --project="$PROJECT_ID" &>/dev/null; then
+    existing=" [already exists — Enter to keep]"
+  fi
+
+  read -r -p "  ${description}${existing}: " value
+
+  if [ -n "$value" ]; then
+    create_or_update_secret "$name" "$value"
+  elif [ -n "$existing" ]; then
+    echo "  ✓ Kept existing ${name}"
+  else
+    echo "  ⚠ Skipped ${name}"
+  fi
+done
+
+echo ""
+echo "✓ Secret setup complete"

--- a/scripts/sync-data-to-vm.sh
+++ b/scripts/sync-data-to-vm.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --host IP --key PATH [--help]
+
+Copies local ~/archon-data/ contents to the GCP VM, replacing remote data.
+Stops containers before copy and restarts after.
+
+Required arguments:
+  --host    VM IP address (from terraform output instance_ips)
+  --key     Path to SSH private key
+
+Exit codes:
+  0 — sync complete
+  1 — failure
+EOF
+}
+
+HOST=""
+KEY=""
+SSH_USER="chris"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --host) HOST="$2"; shift 2 ;;
+    --key) KEY="$2"; shift 2 ;;
+    --user) SSH_USER="$2"; shift 2 ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "✗ Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [ -z "$HOST" ] || [ -z "$KEY" ]; then
+  echo "✗ --host and --key are required" >&2
+  usage
+  exit 1
+fi
+
+LOCAL_DATA="${HOME}/archon-data"
+if [ ! -d "$LOCAL_DATA" ]; then
+  echo "✗ Local data directory not found: ${LOCAL_DATA}" >&2
+  exit 1
+fi
+
+echo "→ Stopping containers on VM..."
+ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 -i "$KEY" \
+  "${SSH_USER}@${HOST}" "cd ~/archon_core && docker compose down"
+
+echo "→ Syncing ${LOCAL_DATA}/ to VM..."
+scp -o StrictHostKeyChecking=no -i "$KEY" -r \
+  "${LOCAL_DATA}"/* "${SSH_USER}@${HOST}:~/archon-data/"
+
+echo "→ Restarting containers on VM..."
+ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 -i "$KEY" \
+  "${SSH_USER}@${HOST}" "cd ~/archon_core && docker compose up -d"
+
+echo "✓ Data synced and containers restarted"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,11 @@
 terraform {
   required_version = ">= 1.5"
 
+  backend "gcs" {
+    bucket = "archon-tfstate"
+    prefix = "terraform/state"
+  }
+
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/terraform/modules/archon-vm/main.tf
+++ b/terraform/modules/archon-vm/main.tf
@@ -120,6 +120,22 @@ locals {
       exit 1
     fi
 
+    OAUTH2_CLIENT_ID=""
+    OAUTH2_CLIENT_SECRET=""
+    %{ if var.secrets_map.oauth2_client_id != "" ~}
+    echo "  → Fetching oauth2_client_id..."
+    if ! OAUTH2_CLIENT_ID=$$(gcloud secrets versions access latest --secret="${var.secrets_map.oauth2_client_id}" 2>&1); then
+      echo "⚠ Failed to retrieve oauth2_client_id (OAuth2 Proxy will not work until configured)" >&2
+      OAUTH2_CLIENT_ID=""
+    fi
+
+    echo "  → Fetching oauth2_client_secret..."
+    if ! OAUTH2_CLIENT_SECRET=$$(gcloud secrets versions access latest --secret="${var.secrets_map.oauth2_client_secret}" 2>&1); then
+      echo "⚠ Failed to retrieve oauth2_client_secret (OAuth2 Proxy will not work until configured)" >&2
+      OAUTH2_CLIENT_SECRET=""
+    fi
+    %{ endif ~}
+
     echo "✓ All secrets retrieved successfully"
 
     echo "→ Cloning repository..."
@@ -132,6 +148,9 @@ locals {
     ARCHON_DOMAIN=$$(echo $$EXTERNAL_IP | tr '.' '-').sslip.io
     echo "  Domain: $$ARCHON_DOMAIN"
 
+    echo "→ Generating OAuth2 cookie secret..."
+    OAUTH2_COOKIE_SECRET=$$(openssl rand -base64 32)
+
     echo "→ Writing .env file..."
     cat > .env <<EOF
 CLAUDE_CODE_OAUTH_TOKEN=$$CLAUDE_CODE_OAUTH_TOKEN
@@ -139,6 +158,10 @@ GITHUB_TOKEN=$$GITHUB_TOKEN
 DISCORD_BOT_TOKEN=$$DISCORD_BOT_TOKEN
 ARCHON_DOMAIN=$$ARCHON_DOMAIN
 PORT=3000
+OAUTH2_PROXY_CLIENT_ID=$$OAUTH2_CLIENT_ID
+OAUTH2_PROXY_CLIENT_SECRET=$$OAUTH2_CLIENT_SECRET
+OAUTH2_PROXY_COOKIE_SECRET=$$OAUTH2_COOKIE_SECRET
+OAUTH_EMAIL=${var.oauth_email}
 EOF
 
     echo "→ Creating data directory..."

--- a/terraform/modules/archon-vm/variables.tf
+++ b/terraform/modules/archon-vm/variables.tf
@@ -74,9 +74,11 @@ variable "disk_size_gb" {
 variable "secrets_map" {
   description = "GCP Secret Manager secret names for per-instance credentials"
   type = object({
-    claude_oauth_token = string
-    github_token       = string
-    discord_bot_token  = string
+    claude_oauth_token   = string
+    github_token         = string
+    discord_bot_token    = string
+    oauth2_client_id     = optional(string, "")
+    oauth2_client_secret = optional(string, "")
   })
   sensitive = true
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -4,9 +4,11 @@ oauth_email    = "chris@caldwell.ws"
 archon_instances = {
   chris = {
     secrets_map = {
-      claude_oauth_token = "archon-chris-claude-oauth-token"
-      github_token       = "archon-chris-github-token"
-      discord_bot_token  = "archon-chris-discord-bot-token"
+      claude_oauth_token   = "archon-chris-claude-oauth-token"
+      github_token         = "archon-chris-github-token"
+      discord_bot_token    = "archon-chris-discord-bot-token"
+      oauth2_client_id     = "archon-chris-oauth2-client-id"
+      oauth2_client_secret = "archon-chris-oauth2-client-secret"
     }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -24,9 +24,11 @@ variable "archon_instances" {
   description = "Map of instance configurations — map keys become SSH usernames (see terraform.tfvars.example)"
   type = map(object({
     secrets_map = object({
-      claude_oauth_token = string
-      github_token       = string
-      discord_bot_token  = string
+      claude_oauth_token   = string
+      github_token         = string
+      discord_bot_token    = string
+      oauth2_client_id     = optional(string, "")
+      oauth2_client_secret = optional(string, "")
     })
   }))
   sensitive = true


### PR DESCRIPTION
## Summary
- Add `Infrastructure` GitHub Actions workflow that runs terraform apply end-to-end
- Startup script now fetches OAuth2 proxy credentials from Secret Manager (no manual SSH config needed)
- GCS backend for terraform state (created automatically on first run)
- Auto-sets `DEPLOY_HOST` and `DEPLOY_SSH_KEY` secrets after terraform apply
- One-time setup scripts: `setup-gcp-ci.sh`, `setup-gcp-secrets.sh`, `sync-data-to-vm.sh`

## First deploy flow
1. `./scripts/setup-gcp-secrets.sh --project dev-services-497603` (stores all tokens)
2. `./scripts/setup-gcp-ci.sh --project dev-services-497603 --email chris@caldwell.ws` (creates CI service account, sets GH secrets)
3. Trigger Infrastructure workflow from GitHub Actions
4. Update OAuth redirect URI with the domain shown in workflow summary
5. `./scripts/sync-data-to-vm.sh --host IP --key terraform/archon-chris.pem` (copy local data)

## Test plan
- [ ] Verify terraform validates with new optional OAuth2 secrets
- [ ] Run setup-gcp-ci.sh and confirm service account + GH secrets created
- [ ] Trigger Infrastructure workflow — VM created, reachable via SSH
- [ ] Verify .env on VM contains all OAuth2 proxy config
- [ ] Confirm deploy workflow works after infrastructure sets DEPLOY_HOST/DEPLOY_SSH_KEY

🤖 Generated with [Claude Code](https://claude.com/claude-code)