### PR TITLE
fix(infra): recover deployment pipeline and add CI guardrails

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,12 +36,38 @@ jobs:
         working-directory: terraform
         run: |
           terraform init -backend=true -input=false >/dev/null 2>&1
-          DEPLOY_HOST=$(terraform output -json instance_ips | jq -r '.chris')
+
+          DEPLOY_HOST=$(terraform output -json instance_ips 2>/dev/null | jq -r '.chris // empty') || true
+          if [ -z "$DEPLOY_HOST" ] || [ "$DEPLOY_HOST" = "null" ]; then
+            echo "::warning::No VM found in Terraform state — skipping deploy"
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           terraform output -json ssh_private_keys | jq -r '.chris' > /tmp/deploy_key.pem
           chmod 600 /tmp/deploy_key.pem
           echo "host=${DEPLOY_HOST}" >> "$GITHUB_OUTPUT"
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Verify VM is ready
+        if: steps.tf.outputs.ready == 'true'
+        id: precheck
+        env:
+          DEPLOY_HOST: ${{ steps.tf.outputs.host }}
+        run: |
+          if ! ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            -i /tmp/deploy_key.pem \
+            "chris@${DEPLOY_HOST}" \
+            "test -f /var/log/archon-startup-complete && command -v docker >/dev/null" 2>/dev/null; then
+            echo "::warning::VM is not ready (startup incomplete or Docker missing) — skipping deploy"
+            echo "vm_ready=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "✓ VM is ready — proceeding with deploy"
+            echo "vm_ready=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Deploy to GCP VM via SSH
+        if: steps.tf.outputs.ready == 'true' && steps.precheck.outputs.vm_ready == 'true'
         env:
           DEPLOY_HOST: ${{ steps.tf.outputs.host }}
         run: |
@@ -49,31 +75,6 @@ jobs:
             -i /tmp/deploy_key.pem \
             "chris@${DEPLOY_HOST}" bash -s <<'DEPLOY'
           set -euo pipefail
-
-          echo "→ Checking required tools"
-          for cmd in git docker; do
-            if ! command -v "$cmd" &>/dev/null; then
-              echo "✗ $cmd not found, checking if startup script is still running..."
-              if [ -f /var/log/archon-startup.log ] && [ ! -f /var/log/archon-startup-complete ]; then
-                echo "→ Startup script still in progress, waiting up to 5 min..."
-                for attempt in $(seq 1 10); do
-                  sleep 30
-                  if command -v "$cmd" &>/dev/null; then
-                    echo "✓ $cmd now available (attempt $attempt)"
-                    break 2
-                  fi
-                  echo "  Attempt $attempt/10 — still waiting..."
-                done
-              fi
-              if ! command -v "$cmd" &>/dev/null; then
-                echo "✗ Required tool not found: $cmd"
-                echo "→ Startup log (last 30 lines):"
-                sudo cat /var/log/archon-startup.log 2>/dev/null | tail -30 || echo "  No startup log found"
-                exit 1
-              fi
-            fi
-          done
-          echo "✓ All required tools available"
 
           echo "→ Fixing Docker config permissions"
           sudo chown -R "$(whoami):$(whoami)" ~/.docker 2>/dev/null || true
@@ -117,10 +118,19 @@ jobs:
       - name: Deployment Summary
         if: always()
         run: |
+          if [ "${{ steps.tf.outputs.ready }}" != "true" ]; then
+            STATUS="⏭️ Skipped (no VM in Terraform state)"
+          elif [ "${{ steps.precheck.outputs.vm_ready }}" != "true" ]; then
+            STATUS="⏭️ Skipped (VM not ready)"
+          elif [ "${{ job.status }}" = "success" ]; then
+            STATUS="✅ Success"
+          else
+            STATUS="❌ Failed"
+          fi
           {
             echo "## Deploy to Production VM"
-            echo "- **Status:** ${{ job.status == 'success' && '✅ Success' || '❌ Failed' }}"
-            echo "- **Host:** \`${{ steps.tf.outputs.host }}\`"
+            echo "- **Status:** ${STATUS}"
+            echo "- **Host:** \`${{ steps.tf.outputs.host || 'N/A' }}\`"
             echo "- **Commit:** \`${{ github.sha }}\`"
             echo "- **Branch:** \`${{ github.ref_name }}\`"
             echo "- **Triggered by:** ${{ github.event_name }}"

--- a/discord-bot/Dockerfile
+++ b/discord-bot/Dockerfile
@@ -8,10 +8,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
-RUN curl -fsSL https://storage.googleapis.com/anthropic-release/claude/latest/install.sh | sh \
-    && CLAUDE_PATH=$(find /root -path "*/bin/claude" -type f 2>/dev/null | head -1) \
-    && echo "Found claude at: $CLAUDE_PATH" \
-    && cp "$CLAUDE_PATH" /usr/local/bin/claude \
+RUN curl -fsSL https://claude.ai/install.sh | sh \
+    && cp /root/.local/bin/claude /usr/local/bin/claude \
     && chmod +x /usr/local/bin/claude
 
 FROM python:3.12-slim-bullseye
@@ -22,9 +20,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY --from=builder /usr/local/bin/claude /usr/local/bin/claude
-COPY --from=builder /root/.claude/ /home/botuser/.claude/
 
 RUN groupadd -g 1000 botuser && useradd -u 1000 -g botuser -m botuser
+RUN mkdir -p /home/botuser/.claude
 RUN mkdir -p /data/threads /data/projects && chown -R botuser:botuser /data
 
 WORKDIR /app

--- a/scripts/setup-gcp-ci.sh
+++ b/scripts/setup-gcp-ci.sh
@@ -68,12 +68,12 @@ else
 fi
 
 ROLES=(
-  "roles/compute.admin"
-  "roles/secretmanager.admin"
-  "roles/iam.serviceAccountAdmin"
-  "roles/iam.serviceAccountUser"
-  "roles/storage.admin"
-  "roles/resourcemanager.projectIamAdmin"
+  "roles/compute.admin"            # Create/manage VMs
+  "roles/secretmanager.admin"      # Read secrets for VM startup script
+  "roles/iam.serviceAccountAdmin"  # Create per-VM service accounts
+  "roles/iam.serviceAccountUser"   # Attach service accounts to VMs
+  "roles/storage.admin"            # Terraform state bucket (GCS)
+  "roles/resourcemanager.projectIamAdmin"  # Terraform grants IAM bindings to VM SAs
 )
 
 echo "→ Granting IAM roles..."

--- a/terraform/modules/archon-vm/main.tf
+++ b/terraform/modules/archon-vm/main.tf
@@ -140,7 +140,7 @@ locals {
 
     echo "→ Resolving sslip.io domain..."
     EXTERNAL_IP=$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H "Metadata-Flavor: Google")
-    ARCHON_DOMAIN=$(echo $EXTERNAL_IP | tr '.' '-').sslip.io
+    ARCHON_DOMAIN=$(echo "$EXTERNAL_IP" | tr '.' '-').sslip.io
     echo "  Domain: $ARCHON_DOMAIN"
 
     echo "→ Generating OAuth2 cookie secret..."


### PR DESCRIPTION
## Summary

- Fix discord-bot Dockerfile: correct Claude CLI install URL (`claude.ai/install.sh`) and known binary path (`~/.local/bin/claude`), remove fragile `COPY --from=builder /root/.claude/`
- Add deploy workflow VM readiness pre-check: skip gracefully (warning, not failure) when VM isn't ready or Terraform state is empty, removing redundant 5-min retry loop
- Document IAM role justifications in `setup-gcp-ci.sh`, fix unquoted shell variable in Terraform startup script
- Enable branch protection on `main` via GitHub API (PRs required with 0 approvals, force push blocked) to prevent future bot-push-loop incidents

Closes #63

## Test plan

- [ ] Run manual Infrastructure workflow (`apply`) to verify discord-bot profile fix unblocks startup
- [ ] Run manual Deploy workflow to verify pre-check skips gracefully when VM not ready
- [ ] Verify `docker compose --profile discord build` succeeds with corrected Dockerfile
- [ ] Confirm branch protection blocks direct push to `main`
- [ ] Confirm self-merge PR flow still works with 0 required approvals

🤖 Generated with [Claude Code](https://claude.com/claude-code)