### PR TITLE
fix: Dockerfile node paths + discord-bot data mount

### DIFF
--- a/discord-bot/Dockerfile
+++ b/discord-bot/Dockerfile
@@ -20,9 +20,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
-COPY --from=builder /usr/local/bin/node /usr/local/bin/node
-COPY --from=builder /usr/local/lib/node_modules /usr/local/lib/node_modules
-RUN ln -s /usr/local/lib/node_modules/.bin/claude /usr/local/bin/claude
+COPY --from=builder /usr/bin/node /usr/bin/node
+COPY --from=builder /usr/lib/node_modules /usr/lib/node_modules
+RUN ln -s /usr/lib/node_modules/.bin/claude /usr/local/bin/claude
 
 RUN groupadd -g 1000 botuser && useradd -u 1000 -g botuser -m botuser
 RUN mkdir -p /home/botuser/.claude /data/threads /data/projects && chown -R botuser:botuser /data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     volumes:
       - ./discord-bot:/app:ro
       - ./scripts/discord-bot-entrypoint.sh:/entrypoint.sh:ro
-      - ./.archon/commands:/.claude/commands:ro
+      - ${HOME}/archon-data/commands:/.claude/commands:ro
       - ${HOME}/archon-data/discord-bot:/data
       - ${HOME}/archon-data/claude-home:/home/botuser/.claude
     working_dir: /app


### PR DESCRIPTION
## Summary
- Fix Node.js paths in discord-bot Dockerfile — NodeSource apt installs to `/usr/bin/node` and `/usr/lib/node_modules`, not `/usr/local/`
- Fix discord-bot commands mount to read from persistent volume (`~/archon-data/commands`) instead of the repo (`./.archon/commands`)

Deploy from #68 failed because the Dockerfile COPY paths were wrong. The commands mount was the last remaining repo overlay — now all data comes from the persistent volume.

## Test plan
- [ ] Deploy succeeds (discord-bot image builds)
- [ ] `docker compose exec discord-bot claude --version` returns a version
- [ ] Discord bot can read slash commands from persistent storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)