### PR TITLE
fix: discord-bot Dockerfile single-stage build

### DIFF
--- a/discord-bot/Dockerfile
+++ b/discord-bot/Dockerfile
@@ -1,28 +1,15 @@
-FROM python:3.12-slim-bullseye AS builder
+FROM python:3.12-slim-bullseye
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir -r /tmp/requirements.txt
-
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
-    && rm -rf /var/lib/apt/lists/* \
+RUN pip install --no-cache-dir -r /tmp/requirements.txt \
     && npm install -g @anthropic-ai/claude-code
-
-FROM python:3.12-slim-bullseye
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
-COPY --from=builder /usr/bin/node /usr/bin/node
-COPY --from=builder /usr/lib/node_modules /usr/lib/node_modules
-RUN ln -s /usr/lib/node_modules/.bin/claude /usr/local/bin/claude
 
 RUN groupadd -g 1000 botuser && useradd -u 1000 -g botuser -m botuser
 RUN mkdir -p /home/botuser/.claude /data/threads /data/projects && chown -R botuser:botuser /data


### PR DESCRIPTION
## Summary
- Replace multi-stage Dockerfile with single-stage — the multi-stage COPY was losing npm symlinks, causing `claude: not found` at runtime
- `npm install -g @anthropic-ai/claude-code` now runs directly in the runtime image, putting `claude` in `/usr/bin/claude` where the bot expects it

Fixes the deploy failure from #69 — image built successfully but `claude` wasn't in PATH because the symlink from `.bin/claude` didn't survive the cross-stage COPY.

## Test plan
- [ ] Deploy succeeds
- [ ] `docker compose exec discord-bot claude --version` works
- [ ] Discord bot starts without "Claude CLI not found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)