### PR TITLE
fix: mount workspaces into discord-bot for project context

### DIFF
--- a/discord-bot/config.py
+++ b/discord-bot/config.py
@@ -33,7 +33,7 @@ DATA_DIR = os.environ.get("DATA_DIR", "/data")
 COMMANDS_DIR = os.environ.get("COMMANDS_DIR", "/.claude/commands")
 
 CHANNEL_MAP = {
-    "dnd-context": "Thummpy/dnd-context",
+    "dnd-context": "Thummpy/dnd-context/source",
 }
 
 # Archive threads after 100 messages to prevent excessive context length

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,7 @@ services:
       - ${HOME}/archon-data/commands:/.claude/commands:ro
       - ${HOME}/archon-data/discord-bot:/data
       - ${HOME}/archon-data/claude-home:/home/botuser/.claude
+      - ${HOME}/archon-data/workspaces:/data/projects:ro
     working_dir: /app
     entrypoint: ["/bin/bash", "/entrypoint.sh"]
     networks:


### PR DESCRIPTION
## Summary
- Mounts `${HOME}/archon-data/workspaces` into the discord-bot container at `/data/projects:ro` so Claude CLI can access project context when responding in mapped Discord channels
- Updates `CHANNEL_MAP` path from `Thummpy/dnd-context` to `Thummpy/dnd-context/source` to point at the actual git clone (not the workspace wrapper dir)

## What was broken
The discord-bot's `_project_dir_for_channel()` resolved to `/data/projects/Thummpy/dnd-context`, but the workspace files only existed inside the archon app container at `/.archon/workspaces/`. The discord-bot container had no access to project files, so Claude CLI had no project context.

## Test plan
- [ ] Merge and let deploy run
- [ ] Send a message in #dnd-context on Discord
- [ ] Verify the bot responds with project-aware context (not generic Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)