### PR TITLE
fix: add init to docker containers to prevent zombie accumulation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       - app
 
   discord-bot:
+    init: true
     build:
       context: ./discord-bot
     container_name: archon-discord-bot
@@ -93,6 +94,7 @@ services:
       - app
 
   caddy:
+    init: true
     image: caddy:2.9-alpine
     container_name: archon-caddy
     environment:


### PR DESCRIPTION
## Summary
- Added `init: true` to **caddy** and **discord-bot** services in docker-compose.yml
- This injects `tini` as PID 1 inside each container to automatically reap zombie child processes
- Fixes an issue where 3,200+ zombie `ssl_client` and `git` processes accumulated on the GCP VM, likely contributing to Archon becoming unresponsive

## Test plan
- [ ] Verify containers start successfully after redeploy
- [ ] Monitor `ps aux | grep Z | wc -l` on the VM over time to confirm zombies no longer accumulate
- [ ] Confirm Archon remains responsive in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)