### PR TITLE
Fix: Discord bot shows all text blocks from Claude responses

### DIFF
--- a/discord-bot/claude_runner.py
+++ b/discord-bot/claude_runner.py
@@ -216,7 +216,9 @@ async def run_claude(
             block["text"] for block in blocks if block.get("type") == "text"
         ]
         text = "\n\n".join(text_parts)
-    except (json.JSONDecodeError, KeyError, TypeError):
-        logger.warning("Failed to parse Claude JSON response, falling back to raw text")
+        if not text and blocks:
+            logger.warning("Claude response contained %d blocks but no text blocks", len(blocks))
+    except (json.JSONDecodeError, KeyError, TypeError, AttributeError) as exc:
+        logger.warning("Failed to parse Claude JSON response (%s), falling back to raw text: %.200s", exc, raw)
         text = raw
     return {"text": text, "trace": []}

--- a/discord-bot/claude_runner.py
+++ b/discord-bot/claude_runner.py
@@ -132,7 +132,7 @@ async def run_claude(
 
     prompt = _apply_style_steering(prompt, project_dir, session_id)
 
-    base_cmd = ["claude", "-p", prompt, "--output-format", "text", "--model", "claude-opus-4-6[1m]"]
+    base_cmd = ["claude", "-p", prompt, "--output-format", "json", "--model", "claude-opus-4-6[1m]"]
 
     if session_id:
         if is_new_session:
@@ -210,4 +210,13 @@ async def run_claude(
         logger.warning("Claude subprocess wrote to stderr (exit_code=0): %s", err_msg[:1000])
 
     raw = stdout.decode("utf-8", errors="replace").strip()
-    return {"text": raw, "trace": []}
+    try:
+        blocks = json.loads(raw)
+        text_parts = [
+            block["text"] for block in blocks if block.get("type") == "text"
+        ]
+        text = "\n\n".join(text_parts)
+    except (json.JSONDecodeError, KeyError, TypeError):
+        logger.warning("Failed to parse Claude JSON response, falling back to raw text")
+        text = raw
+    return {"text": text, "trace": []}

--- a/discord-bot/claude_runner.py
+++ b/discord-bot/claude_runner.py
@@ -161,6 +161,14 @@ async def run_claude(
             proc.communicate(),
             timeout=config.CLAUDE_TIMEOUT_SECONDS,
         )
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        elapsed = time.monotonic() - start
+        logger.error("Claude subprocess timed out elapsed=%.1fs", elapsed)
+        raise TimeoutError(
+            f"Claude did not respond within {config.CLAUDE_TIMEOUT_SECONDS}s"
+        )
     except FileNotFoundError:
         logger.error("Claude CLI binary not found - is it installed?")
         raise RuntimeError(
@@ -176,14 +184,6 @@ async def run_claude(
         raise RuntimeError(
             f"Could not spawn Claude CLI process (OS error: {exc.strerror or str(exc)}). "
             "Contact the bot admin - system resources may be exhausted."
-        )
-    except asyncio.TimeoutError:
-        proc.kill()
-        await proc.wait()
-        elapsed = time.monotonic() - start
-        logger.error("Claude subprocess timed out elapsed=%.1fs", elapsed)
-        raise TimeoutError(
-            f"Claude did not respond within {config.CLAUDE_TIMEOUT_SECONDS}s"
         )
 
     elapsed = time.monotonic() - start

--- a/discord-bot/tests/test_claude_runner.py
+++ b/discord-bot/tests/test_claude_runner.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock, patch
 import asyncio
+import json
 import sys
 import os
 
@@ -160,9 +161,10 @@ async def test_run_claude_nonzero_exit_code(mock_exec):
 @pytest.mark.asyncio
 @patch('claude_runner.asyncio.create_subprocess_exec', new_callable=AsyncMock)
 async def test_run_claude_success_returns_text(mock_exec):
-    """Should return text on success."""
+    """Should return text parsed from JSON on success."""
     mock_proc = AsyncMock()
-    mock_proc.communicate.return_value = (b"Claude response text", b"")
+    json_response = json.dumps([{"type": "text", "text": "Claude response text"}])
+    mock_proc.communicate.return_value = (json_response.encode(), b"")
     mock_proc.returncode = 0
     mock_exec.return_value = mock_proc
 
@@ -174,10 +176,52 @@ async def test_run_claude_success_returns_text(mock_exec):
 
 @pytest.mark.asyncio
 @patch('claude_runner.asyncio.create_subprocess_exec', new_callable=AsyncMock)
+async def test_run_claude_multi_block_response(mock_exec):
+    """Should concatenate all text blocks from multi-block response."""
+    mock_proc = AsyncMock()
+    json_response = json.dumps([
+        {"type": "text", "text": "Rue hits the guard with a devastating blow..."},
+        {"type": "tool_use", "id": "tool_1", "name": "roll_dice", "input": {}},
+        {"type": "tool_result", "tool_use_id": "tool_1", "content": "18"},
+        {"type": "text", "text": "The guard staggers, then retaliates..."},
+    ])
+    mock_proc.communicate.return_value = (json_response.encode(), b"")
+    mock_proc.returncode = 0
+    mock_exec.return_value = mock_proc
+
+    result = await run_claude(prompt="hello")
+
+    assert "Rue hits the guard" in result["text"]
+    assert "The guard staggers" in result["text"]
+    assert result["text"] == (
+        "Rue hits the guard with a devastating blow..."
+        "\n\n"
+        "The guard staggers, then retaliates..."
+    )
+
+
+@pytest.mark.asyncio
+@patch('claude_runner.asyncio.create_subprocess_exec', new_callable=AsyncMock)
+async def test_run_claude_json_parse_error_fallback(mock_exec):
+    """Should fall back to raw text when JSON parsing fails."""
+    mock_proc = AsyncMock()
+    mock_proc.communicate.return_value = (b"not valid json", b"")
+    mock_proc.returncode = 0
+    mock_exec.return_value = mock_proc
+
+    result = await run_claude(prompt="hello")
+
+    assert result["text"] == "not valid json"
+    assert result["trace"] == []
+
+
+@pytest.mark.asyncio
+@patch('claude_runner.asyncio.create_subprocess_exec', new_callable=AsyncMock)
 async def test_run_claude_stderr_warning_on_success(mock_exec):
     """Should log warning if stderr present on success."""
     mock_proc = AsyncMock()
-    mock_proc.communicate.return_value = (b"response", b"warning message")
+    json_response = json.dumps([{"type": "text", "text": "response"}])
+    mock_proc.communicate.return_value = (json_response.encode(), b"warning message")
     mock_proc.returncode = 0
     mock_exec.return_value = mock_proc
 

--- a/discord-bot/tests/test_claude_runner.py
+++ b/discord-bot/tests/test_claude_runner.py
@@ -17,7 +17,8 @@ from claude_runner import run_claude
 async def test_run_claude_new_session_command(mock_exec):
     """New session should use --session-id flag."""
     mock_proc = AsyncMock()
-    mock_proc.communicate.return_value = (b"response", b"")
+    json_response = json.dumps([{"type": "text", "text": "response"}])
+    mock_proc.communicate.return_value = (json_response.encode(), b"")
     mock_proc.returncode = 0
     mock_exec.return_value = mock_proc
 
@@ -41,7 +42,8 @@ async def test_run_claude_new_session_command(mock_exec):
 async def test_run_claude_resume_session_command(mock_exec):
     """Resume session should use --resume flag."""
     mock_proc = AsyncMock()
-    mock_proc.communicate.return_value = (b"response", b"")
+    json_response = json.dumps([{"type": "text", "text": "response"}])
+    mock_proc.communicate.return_value = (json_response.encode(), b"")
     mock_proc.returncode = 0
     mock_exec.return_value = mock_proc
 
@@ -63,7 +65,8 @@ async def test_run_claude_resume_session_command(mock_exec):
 async def test_run_claude_no_session_command(mock_exec):
     """No session should use neither --session-id nor --resume."""
     mock_proc = AsyncMock()
-    mock_proc.communicate.return_value = (b"response", b"")
+    json_response = json.dumps([{"type": "text", "text": "response"}])
+    mock_proc.communicate.return_value = (json_response.encode(), b"")
     mock_proc.returncode = 0
     mock_exec.return_value = mock_proc
 
@@ -73,6 +76,8 @@ async def test_run_claude_no_session_command(mock_exec):
     cmd = args
     assert "--session-id" not in cmd
     assert "--resume" not in cmd
+    assert "--output-format" in cmd
+    assert "json" in cmd
 
 
 @pytest.mark.asyncio
@@ -80,7 +85,8 @@ async def test_run_claude_no_session_command(mock_exec):
 async def test_run_claude_invalid_state_is_new_without_session_id(mock_exec):
     """is_new_session=True with session_id=None should use one-off mode (current behavior)."""
     mock_proc = AsyncMock()
-    mock_proc.communicate.return_value = (b"response", b"")
+    json_response = json.dumps([{"type": "text", "text": "response"}])
+    mock_proc.communicate.return_value = (json_response.encode(), b"")
     mock_proc.returncode = 0
     mock_exec.return_value = mock_proc
 
@@ -99,7 +105,8 @@ async def test_run_claude_invalid_state_is_new_without_session_id(mock_exec):
 async def test_run_claude_with_project_dir(mock_exec):
     """Should pass project_dir as cwd to subprocess."""
     mock_proc = AsyncMock()
-    mock_proc.communicate.return_value = (b"response", b"")
+    json_response = json.dumps([{"type": "text", "text": "response"}])
+    mock_proc.communicate.return_value = (json_response.encode(), b"")
     mock_proc.returncode = 0
     mock_exec.return_value = mock_proc
 
@@ -239,3 +246,37 @@ async def test_run_claude_os_error(mock_exec):
 
     with pytest.raises(RuntimeError, match="Could not spawn Claude CLI process"):
         await run_claude(prompt="hello")
+
+
+@pytest.mark.asyncio
+@patch('claude_runner.asyncio.create_subprocess_exec', new_callable=AsyncMock)
+async def test_run_claude_json_wrong_structure_fallback(mock_exec):
+    """Should fall back to raw text when JSON is valid but not an array of blocks."""
+    mock_proc = AsyncMock()
+    json_response = json.dumps({"type": "text", "text": "unexpected object"})
+    mock_proc.communicate.return_value = (json_response.encode(), b"")
+    mock_proc.returncode = 0
+    mock_exec.return_value = mock_proc
+
+    result = await run_claude(prompt="hello")
+
+    assert result["text"] == json_response
+    assert result["trace"] == []
+
+
+@pytest.mark.asyncio
+@patch('claude_runner.asyncio.create_subprocess_exec', new_callable=AsyncMock)
+async def test_run_claude_no_text_blocks(mock_exec):
+    """Should return empty string when response has no text blocks."""
+    mock_proc = AsyncMock()
+    json_response = json.dumps([
+        {"type": "tool_use", "id": "tool_1", "name": "roll_dice", "input": {}},
+    ])
+    mock_proc.communicate.return_value = (json_response.encode(), b"")
+    mock_proc.returncode = 0
+    mock_exec.return_value = mock_proc
+
+    result = await run_claude(prompt="hello")
+
+    assert result["text"] == ""
+    assert result["trace"] == []

--- a/scripts/discord-bot-entrypoint.sh
+++ b/scripts/discord-bot-entrypoint.sh
@@ -25,7 +25,7 @@ fi
 
 # Restore .claude.json from backup if missing (shared volume may lose it)
 if [ ! -f "$HOME/.claude.json" ]; then
-  BACKUP=$(ls -t "$HOME/.claude/backups/.claude.json.backup."* 2>/dev/null | head -1)
+  BACKUP=$(find "$HOME/.claude/backups" -maxdepth 1 -name '.claude.json.backup.*' -printf '%T@\t%p\n' 2>/dev/null | sort -rn | head -1 | cut -f2)
   if [ -n "$BACKUP" ]; then
     cp "$BACKUP" "$HOME/.claude.json"
     echo "[discord-bot] Restored .claude.json from backup" >&2


### PR DESCRIPTION
## What

Fix Discord bot to show all text blocks from Claude responses instead of only the last one.

## Why

Fixes #86. When Claude's response contains multiple text blocks interspersed with tool_use blocks (e.g., narrative -> dice roll -> narrative), the bot silently drops all text blocks except the last one. This is because `--output-format text` only returns the final text content block from the CLI.

## How

- Changed `--output-format text` to `--output-format json` in `claude_runner.py` so the CLI returns all content blocks as a JSON array.
- Parse the JSON response and extract all `type: "text"` blocks, concatenating them with double newlines. Falls back to raw text on JSON parse errors for resilience.
- Reordered exception handlers so `asyncio.TimeoutError` is caught before `OSError` — in Python 3.11+, `TimeoutError` is a subclass of `OSError`, so the previous order caused timeouts to be caught by the wrong handler.

## Testing

- Updated existing `test_run_claude_success_returns_text` to use JSON format.
- Added `test_run_claude_multi_block_response` — verifies multiple text blocks interspersed with tool_use/tool_result are all concatenated.
- Added `test_run_claude_json_parse_error_fallback` — verifies malformed JSON falls back to raw text.
- Updated `test_run_claude_stderr_warning_on_success` to use JSON format.
- All 27 tests pass: `python3 -m pytest tests/test_claude_runner.py tests/test_thread_manager.py -v`

---

### Checklist

- [x] PRP or task reference linked above
- [ ] `/review` command run with no FAIL items
- [ ] `.claude/scripts/validate.sh` passes
- [x] No unresolved placeholder markers in changed files
- [ ] ADR created (`.claude/docs/adr/`) if architecture was changed
