### PR TITLE
Fix Claude CLI JSON output parsing in Discord bot

### DIFF
--- a/discord-bot/claude_runner.py
+++ b/discord-bot/claude_runner.py
@@ -214,6 +214,8 @@ async def run_claude(
         data = json.loads(raw)
         if isinstance(data, dict) and "result" in data:
             text = data["result"]
+            if data.get("is_error"):
+                logger.warning("Claude returned is_error=True: %.200s", text)
         elif isinstance(data, list):
             text_parts = [
                 block["text"] for block in data if block.get("type") == "text"

--- a/discord-bot/claude_runner.py
+++ b/discord-bot/claude_runner.py
@@ -211,13 +211,19 @@ async def run_claude(
 
     raw = stdout.decode("utf-8", errors="replace").strip()
     try:
-        blocks = json.loads(raw)
-        text_parts = [
-            block["text"] for block in blocks if block.get("type") == "text"
-        ]
-        text = "\n\n".join(text_parts)
-        if not text and blocks:
-            logger.warning("Claude response contained %d blocks but no text blocks", len(blocks))
+        data = json.loads(raw)
+        if isinstance(data, dict) and "result" in data:
+            text = data["result"]
+        elif isinstance(data, list):
+            text_parts = [
+                block["text"] for block in data if block.get("type") == "text"
+            ]
+            text = "\n\n".join(text_parts)
+            if not text and data:
+                logger.warning("Claude response contained %d blocks but no text blocks", len(data))
+        else:
+            logger.warning("Parsed JSON has unexpected shape, falling back to raw text: %.200s", raw)
+            text = raw
     except (json.JSONDecodeError, KeyError, TypeError, AttributeError) as exc:
         logger.warning("Failed to parse Claude JSON response (%s), falling back to raw text: %.200s", exc, raw)
         text = raw

--- a/discord-bot/tests/test_claude_runner.py
+++ b/discord-bot/tests/test_claude_runner.py
@@ -266,6 +266,24 @@ async def test_run_claude_json_wrong_structure_fallback(mock_exec):
 
 @pytest.mark.asyncio
 @patch('claude_runner.asyncio.create_subprocess_exec', new_callable=AsyncMock)
+async def test_run_claude_is_error_flag_logs_warning(mock_exec):
+    """Should log warning when Claude returns is_error=True but still return the text."""
+    mock_proc = AsyncMock()
+    json_response = json.dumps({"type": "result", "result": "Error: context window exceeded", "is_error": True})
+    mock_proc.communicate.return_value = (json_response.encode(), b"")
+    mock_proc.returncode = 0
+    mock_exec.return_value = mock_proc
+
+    import logging
+    with patch('claude_runner.logger') as mock_logger:
+        result = await run_claude(prompt="hello")
+
+    assert result["text"] == "Error: context window exceeded"
+    mock_logger.warning.assert_any_call("Claude returned is_error=True: %.200s", "Error: context window exceeded")
+
+
+@pytest.mark.asyncio
+@patch('claude_runner.asyncio.create_subprocess_exec', new_callable=AsyncMock)
 async def test_run_claude_no_text_blocks(mock_exec):
     """Should return empty string when response has no text blocks."""
     mock_proc = AsyncMock()

--- a/discord-bot/tests/test_claude_runner.py
+++ b/discord-bot/tests/test_claude_runner.py
@@ -17,7 +17,7 @@ from claude_runner import run_claude
 async def test_run_claude_new_session_command(mock_exec):
     """New session should use --session-id flag."""
     mock_proc = AsyncMock()
-    json_response = json.dumps([{"type": "text", "text": "response"}])
+    json_response = json.dumps({"type": "result", "result": "response", "is_error": False})
     mock_proc.communicate.return_value = (json_response.encode(), b"")
     mock_proc.returncode = 0
     mock_exec.return_value = mock_proc
@@ -42,7 +42,7 @@ async def test_run_claude_new_session_command(mock_exec):
 async def test_run_claude_resume_session_command(mock_exec):
     """Resume session should use --resume flag."""
     mock_proc = AsyncMock()
-    json_response = json.dumps([{"type": "text", "text": "response"}])
+    json_response = json.dumps({"type": "result", "result": "response", "is_error": False})
     mock_proc.communicate.return_value = (json_response.encode(), b"")
     mock_proc.returncode = 0
     mock_exec.return_value = mock_proc
@@ -65,7 +65,7 @@ async def test_run_claude_resume_session_command(mock_exec):
 async def test_run_claude_no_session_command(mock_exec):
     """No session should use neither --session-id nor --resume."""
     mock_proc = AsyncMock()
-    json_response = json.dumps([{"type": "text", "text": "response"}])
+    json_response = json.dumps({"type": "result", "result": "response", "is_error": False})
     mock_proc.communicate.return_value = (json_response.encode(), b"")
     mock_proc.returncode = 0
     mock_exec.return_value = mock_proc
@@ -85,7 +85,7 @@ async def test_run_claude_no_session_command(mock_exec):
 async def test_run_claude_invalid_state_is_new_without_session_id(mock_exec):
     """is_new_session=True with session_id=None should use one-off mode (current behavior)."""
     mock_proc = AsyncMock()
-    json_response = json.dumps([{"type": "text", "text": "response"}])
+    json_response = json.dumps({"type": "result", "result": "response", "is_error": False})
     mock_proc.communicate.return_value = (json_response.encode(), b"")
     mock_proc.returncode = 0
     mock_exec.return_value = mock_proc
@@ -105,7 +105,7 @@ async def test_run_claude_invalid_state_is_new_without_session_id(mock_exec):
 async def test_run_claude_with_project_dir(mock_exec):
     """Should pass project_dir as cwd to subprocess."""
     mock_proc = AsyncMock()
-    json_response = json.dumps([{"type": "text", "text": "response"}])
+    json_response = json.dumps({"type": "result", "result": "response", "is_error": False})
     mock_proc.communicate.return_value = (json_response.encode(), b"")
     mock_proc.returncode = 0
     mock_exec.return_value = mock_proc
@@ -168,9 +168,9 @@ async def test_run_claude_nonzero_exit_code(mock_exec):
 @pytest.mark.asyncio
 @patch('claude_runner.asyncio.create_subprocess_exec', new_callable=AsyncMock)
 async def test_run_claude_success_returns_text(mock_exec):
-    """Should return text parsed from JSON on success."""
+    """Should return text parsed from result-object JSON on success."""
     mock_proc = AsyncMock()
-    json_response = json.dumps([{"type": "text", "text": "Claude response text"}])
+    json_response = json.dumps({"type": "result", "result": "Claude response text", "is_error": False})
     mock_proc.communicate.return_value = (json_response.encode(), b"")
     mock_proc.returncode = 0
     mock_exec.return_value = mock_proc
@@ -227,7 +227,7 @@ async def test_run_claude_json_parse_error_fallback(mock_exec):
 async def test_run_claude_stderr_warning_on_success(mock_exec):
     """Should log warning if stderr present on success."""
     mock_proc = AsyncMock()
-    json_response = json.dumps([{"type": "text", "text": "response"}])
+    json_response = json.dumps({"type": "result", "result": "response", "is_error": False})
     mock_proc.communicate.return_value = (json_response.encode(), b"warning message")
     mock_proc.returncode = 0
     mock_exec.return_value = mock_proc
@@ -251,9 +251,9 @@ async def test_run_claude_os_error(mock_exec):
 @pytest.mark.asyncio
 @patch('claude_runner.asyncio.create_subprocess_exec', new_callable=AsyncMock)
 async def test_run_claude_json_wrong_structure_fallback(mock_exec):
-    """Should fall back to raw text when JSON is valid but not an array of blocks."""
+    """Should fall back to raw text when JSON is valid but has unexpected shape (no result key, not a list)."""
     mock_proc = AsyncMock()
-    json_response = json.dumps({"type": "text", "text": "unexpected object"})
+    json_response = json.dumps({"status": "unknown", "data": "unexpected object"})
     mock_proc.communicate.return_value = (json_response.encode(), b"")
     mock_proc.returncode = 0
     mock_exec.return_value = mock_proc


### PR DESCRIPTION
## What

Fix JSON output parsing in `claude_runner.py` — the CLI's `--output-format json` returns a result object (`{"type":"result","result":"<text>"}`), not a list of content blocks. The parser hit a TypeError and fell back to dumping raw JSON to Discord.

## Why

Issue #86. The Discord bot was showing raw JSON instead of readable text because the parsing logic assumed a list format that the CLI no longer produces.

## How

- Added result-object detection as the primary parsing path (`parsed["result"]`)
- Kept list-of-blocks iteration as a fallback for forward compatibility
- Preserved raw-text last-resort fallback
- Added warning log for unexpected JSON shapes

## Testing

```bash
cd discord-bot && CLAUDE_CODE_OAUTH_TOKEN=test DISCORD_BOT_TOKEN=test DISCORD_SERVER_ID=1 python3 -m pytest tests/test_claude_runner.py -v
```

- 16/16 tests pass
- 8 test mocks updated to result-object format
- Fallback paths covered by `test_run_claude_multi_block_response` (list format) and `test_run_claude_json_wrong_structure_fallback` (dict without `result` key)

---

### Checklist

- [x] PRP or task reference linked above
- [x] `/review` command run with no FAIL items
- [ ] `.claude/scripts/validate.sh` passes
- [x] No unresolved placeholder markers in changed files
- [ ] ADR created (`.claude/docs/adr/`) if architecture was changed — N/A, no architecture change
