### PR TITLE
Upgrade Discord bot to Claude Opus 5

### DIFF
--- a/discord-bot/claude_runner.py
+++ b/discord-bot/claude_runner.py
@@ -132,7 +132,7 @@ async def run_claude(
 
     prompt = _apply_style_steering(prompt, project_dir, session_id)
 
-    base_cmd = ["claude", "-p", prompt, "--output-format", "json", "--model", "claude-opus-4-6[1m]"]
+    base_cmd = ["claude", "-p", prompt, "--output-format", "json", "--model", "claude-opus-5"]
 
     if session_id:
         if is_new_session:


### PR DESCRIPTION
## Summary
- Swap model ID from `claude-opus-4-6[1m]` to `claude-opus-5` in `discord-bot/claude_runner.py`
- Opus 5 has 1M context by default (no suffix needed), 128k max output, same pricing

## Test plan
- [ ] Merge and deploy
- [ ] Send a message in Discord, verify bot responds using Opus 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)