### PR TITLE
Revert Discord bot to Claude Opus 4.6 (1M)

### DIFF
--- a/discord-bot/claude_runner.py
+++ b/discord-bot/claude_runner.py
@@ -132,7 +132,7 @@ async def run_claude(
 
     prompt = _apply_style_steering(prompt, project_dir, session_id)
 
-    base_cmd = ["claude", "-p", prompt, "--output-format", "json", "--model", "claude-opus-5"]
+    base_cmd = ["claude", "-p", prompt, "--output-format", "json", "--model", "claude-opus-4-6[1m]"]
 
     if session_id:
         if is_new_session:


### PR DESCRIPTION
## Summary
- Reverts model ID from `claude-opus-5` back to `claude-opus-4-6[1m]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)