### PR TITLE
Pin orchestrator model to claude-opus-4-6[1m]

### DIFF
--- a/.archon/config.yaml
+++ b/.archon/config.yaml
@@ -1,0 +1,3 @@
+assistants:
+  claude:
+    model: "claude-opus-4-6[1m]"


### PR DESCRIPTION
## Summary
- Adds `.archon/config.yaml` with `assistants.claude.model: "claude-opus-4-6[1m]"` to enable Opus 4.6 with medium-effort extended thinking
- Previous attempt (437852d, reverted in 92df820) broke things by including `settingSources: []` — this version only sets the model field
- Force-added since `.archon/config.yaml` is gitignored (same pattern as `.archon/workflows/`)

## Context
The global `/.archon/config.yaml` (on the persistent volume) defaults to `claude-opus-4-6` without extended thinking. This repo-level config overrides it per the config loader hierarchy: Defaults → Global → **Repo** → Env vars.

## Test plan
- [ ] Merge and redeploy — verify new orchestrator sessions report model as `claude-opus-4-6[1m]`
- [ ] Confirm extended thinking output appears in conversation responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)